### PR TITLE
Batch Mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,10 +33,8 @@
     "electron-prebuilt": "^0.30.1",
     "mocha": "^2.3.4",
     "phonetic": "^0.1.0",
+    "random-seed": "^0.2.0",
     "standard": "^4.5.4"
-  },
-  "dependencies": {
-    "random-seed": "^0.2.0"
   },
   "standard": {
     "parser": "babel-eslint",

--- a/package.json
+++ b/package.json
@@ -33,8 +33,10 @@
     "electron-prebuilt": "^0.30.1",
     "mocha": "^2.3.4",
     "phonetic": "^0.1.0",
-    "random-seed": "^0.2.0",
     "standard": "^4.5.4"
+  },
+  "dependencies": {
+    "random-seed": "^0.2.0"
   },
   "standard": {
     "parser": "babel-eslint",

--- a/src/iterator.js
+++ b/src/iterator.js
@@ -166,6 +166,7 @@ export default class Iterator {
 
     if (!this.currentNode) {
       this.patch.root = new Node(null, boundaryOutputPosition, boundaryOutputPosition)
+      this.patch.nodesCount++
       return this.patch.root
     }
 
@@ -183,6 +184,7 @@ export default class Iterator {
           let newNode = new Node(this.currentNode, inputLeftExtent, outputLeftExtent)
           this.currentNode.left = newNode
           this.descendLeft()
+          this.patch.nodesCount++
           break
         }
       } else if (comparison === 0 && this.currentNode !== spliceStartNode) {
@@ -196,6 +198,7 @@ export default class Iterator {
           let newNode = new Node(this.currentNode, inputLeftExtent, outputLeftExtent)
           this.currentNode.right = newNode
           this.descendRight()
+          this.patch.nodesCount++
           break
         }
       }
@@ -220,6 +223,7 @@ export default class Iterator {
 
     if (!this.currentNode) {
       this.patch.root = new Node(null, boundaryInputPosition, boundaryInputPosition)
+      this.patch.nodesCount++
       return this.patch.root
     }
 
@@ -241,6 +245,7 @@ export default class Iterator {
           let newNode = new Node(this.currentNode, inputLeftExtent, outputLeftExtent)
           this.currentNode.left = newNode
           this.descendLeft()
+          this.patch.nodesCount++
           break
         }
       } else {
@@ -262,6 +267,7 @@ export default class Iterator {
           let newNode = new Node(this.currentNode, inputLeftExtent, outputLeftExtent)
           this.currentNode.right = newNode
           this.descendRight()
+          this.patch.nodesCount++
           break
         }
       }

--- a/src/iterator.js
+++ b/src/iterator.js
@@ -58,6 +58,10 @@ export default class Iterator {
     return changes
   }
 
+  getCurrentNode () {
+    return this.currentNode
+  }
+
   inChange () {
     return this.currentNode && this.currentNode.isChangeEnd
   }

--- a/src/node.js
+++ b/src/node.js
@@ -11,7 +11,6 @@ export default class Node {
     this.outputExtent = outputLeftExtent
 
     this.id = ++idCounter
-    this.priority = 0
     this.isChangeStart = false
     this.isChangeEnd = false
     this.newText = null

--- a/src/node.js
+++ b/src/node.js
@@ -11,6 +11,7 @@ export default class Node {
     this.outputExtent = outputLeftExtent
 
     this.id = ++idCounter
+    this.priority = 0
     this.isChangeStart = false
     this.isChangeEnd = false
     this.newText = null

--- a/src/node.js
+++ b/src/node.js
@@ -11,7 +11,7 @@ export default class Node {
     this.outputExtent = outputLeftExtent
 
     this.id = ++idCounter
-    this.priority = Infinity
+    this.priority = 0
     this.isChangeStart = false
     this.isChangeEnd = false
     this.newText = null

--- a/src/patch.js
+++ b/src/patch.js
@@ -74,11 +74,8 @@ export default class Patch {
     }
 
     if (startNode.isChangeStart && startNode.isChangeEnd && this.combineChanges) {
-      if (this.batchMode && this.root !== startNode) {
-        this.rotateNodeRight(startNode)
-      }
       startNode.priority = Infinity
-      let rightAncestor = this.bubbleNodeDown(startNode)
+      let rightAncestor = this.bubbleNodeDown(startNode) || endNode
       if (startNode.newText != null) {
         rightAncestor.newText = startNode.newText + rightAncestor.newText
       }

--- a/src/patch.js
+++ b/src/patch.js
@@ -6,6 +6,7 @@ import Iterator from './iterator'
 export default class Patch {
   constructor (params = {}) {
     this.combineChanges = (params.combineChanges != null) ? Boolean(params.combineChanges) : true
+    this.batchMode = (params.batchMode != null) ? Boolean(params.batchMode) : false
     if (params.seed) {
       let randomGenerator = new Random(params.seed)
       this.generateRandom = randomGenerator.random.bind(randomGenerator)
@@ -214,6 +215,55 @@ export default class Patch {
     }
 
     return rightAncestor
+  }
+
+  splayNode (node) {
+    while (true) {
+      if (this.isNodeRightChildOfLeftChild(node)) {
+        this.rotateNodeLeft(node)
+        this.rotateNodeRight(node)
+      } else if (this.isNodeLeftChildOfRightChild(node)) {
+        this.rotateNodeRight(node)
+        this.rotateNodeLeft(node)
+      } else if (this.isNodeLeftChildOfLeftChild(node)) {
+        this.rotateNodeRight(node.parent)
+        this.rotateNodeRight(node)
+      } else if (this.isNodeRightChildOfRightChild(node)) {
+        this.rotateNodeLeft(node.parent)
+        this.rotateNodeLeft(node)
+      } else {
+        if (this.isNodeLeftChild(node))
+          this.rotateNodeRight(node)
+        else if (this.isNodeRightChild(node))
+          this.rotateNodeLeft(node)
+
+        return
+      }
+    }
+  }
+
+  isNodeLeftChildOfRightChild (node) {
+    return this.isNodeRightChild(node.parent) && this.isNodeLeftChild(node)
+  }
+
+  isNodeRightChildOfLeftChild (node) {
+    return this.isNodeLeftChild(node.parent) && this.isNodeRightChild(node)
+  }
+
+  isNodeLeftChildOfLeftChild (node) {
+    return this.isNodeLeftChild(node.parent) && this.isNodeLeftChild(node)
+  }
+
+  isNodeRightChildOfRightChild (node) {
+    return this.isNodeRightChild(node.parent) && this.isNodeRightChild(node)
+  }
+
+  isNodeLeftChild (node) {
+    return node != null && node.parent != null && node.parent.left === node
+  }
+
+  isNodeRightChild (node) {
+    return node != null && node.parent != null && node.parent.right === node
   }
 
   rotateNodeLeft (pivot) {

--- a/src/patch.js
+++ b/src/patch.js
@@ -68,14 +68,15 @@ export default class Patch {
         && comparePoints(endNode.inputLeftExtent, startNode.inputLeftExtent) === 0) {
       startNode.isChangeStart = endNode.isChangeStart
       this.deleteNode(endNode)
-    } else if (this.batchMode) {
-      this.rotateNodeRight(startNode)
-    } else {
+    } else if (!this.batchMode) {
       endNode.priority = this.generateRandom()
       this.bubbleNodeDown(endNode)
     }
 
     if (startNode.isChangeStart && startNode.isChangeEnd && this.combineChanges) {
+      if (this.batchMode && this.root !== startNode) {
+        this.rotateNodeRight(startNode)
+      }
       startNode.priority = Infinity
       let rightAncestor = this.bubbleNodeDown(startNode)
       if (startNode.newText != null) {
@@ -241,43 +242,28 @@ export default class Patch {
 
   splayNode (node) {
     while (true) {
-      if (this.isNodeRightChildOfLeftChild(node)) {
+      if (this.isNodeLeftChild(node.parent) && this.isNodeRightChild(node)) { // zig-zag
         this.rotateNodeLeft(node)
         this.rotateNodeRight(node)
-      } else if (this.isNodeLeftChildOfRightChild(node)) {
+      } else if (this.isNodeRightChild(node.parent) && this.isNodeLeftChild(node)) { // zig-zag
         this.rotateNodeRight(node)
         this.rotateNodeLeft(node)
-      } else if (this.isNodeLeftChildOfLeftChild(node)) {
+      } else if (this.isNodeLeftChild(node.parent) && this.isNodeLeftChild(node)) { // zig-zig
         this.rotateNodeRight(node.parent)
         this.rotateNodeRight(node)
-      } else if (this.isNodeRightChildOfRightChild(node)) {
+      } else if (this.isNodeRightChild(node.parent) && this.isNodeRightChild(node)) { // zig-zig
         this.rotateNodeLeft(node.parent)
         this.rotateNodeLeft(node)
-      } else {
-        if (this.isNodeLeftChild(node))
+      } else { // zig
+        if (this.isNodeLeftChild(node)) {
           this.rotateNodeRight(node)
-        else if (this.isNodeRightChild(node))
+        } else if (this.isNodeRightChild(node)) {
           this.rotateNodeLeft(node)
+        }
 
         return
       }
     }
-  }
-
-  isNodeLeftChildOfRightChild (node) {
-    return this.isNodeRightChild(node.parent) && this.isNodeLeftChild(node)
-  }
-
-  isNodeRightChildOfLeftChild (node) {
-    return this.isNodeLeftChild(node.parent) && this.isNodeRightChild(node)
-  }
-
-  isNodeLeftChildOfLeftChild (node) {
-    return this.isNodeLeftChild(node.parent) && this.isNodeLeftChild(node)
-  }
-
-  isNodeRightChildOfRightChild (node) {
-    return this.isNodeRightChild(node.parent) && this.isNodeRightChild(node)
   }
 
   isNodeLeftChild (node) {

--- a/src/patch.js
+++ b/src/patch.js
@@ -170,13 +170,17 @@ export default class Patch {
   translateInputPosition (inputPosition) {
     this.iterator.seekToInputPosition(inputPosition)
     let overshoot = traversalDistance(inputPosition, this.iterator.getInputStart())
-    return minPoint(traverse(this.iterator.getOutputStart(), overshoot), this.iterator.getOutputEnd())
+    let outputPosition = minPoint(traverse(this.iterator.getOutputStart(), overshoot), this.iterator.getOutputEnd())
+    this.splayNode(this.iterator.getCurrentNode())
+    return outputPosition
   }
 
   translateOutputPosition (outputPosition) {
     this.iterator.seekToOutputPosition(outputPosition)
     let overshoot = traversalDistance(outputPosition, this.iterator.getOutputStart())
-    return minPoint(traverse(this.iterator.getInputStart(), overshoot), this.iterator.getInputEnd())
+    let inputPosition = minPoint(traverse(this.iterator.getInputStart(), overshoot), this.iterator.getInputEnd())
+    this.splayNode(this.iterator.getCurrentNode())
+    return inputPosition
   }
 
   getChanges () {
@@ -238,6 +242,8 @@ export default class Patch {
   }
 
   splayNode (node) {
+    if (node == null) return
+
     while (true) {
       if (this.isNodeLeftChild(node.parent) && this.isNodeRightChild(node)) { // zig-zag
         this.rotateNodeLeft(node)

--- a/src/patch.js
+++ b/src/patch.js
@@ -41,7 +41,7 @@ export default class Patch {
     if (this.batchMode) {
       this.splayNode(startNode)
       this.splayNode(endNode)
-      if (endNode.left !== startNode) this.rotateNodeRight(startNode)
+      if (startNode !== endNode && endNode.left !== startNode) this.rotateNodeRight(startNode)
     } else {
       startNode.priority = -1
       this.bubbleNodeUp(startNode)
@@ -68,7 +68,7 @@ export default class Patch {
         && comparePoints(endNode.inputLeftExtent, startNode.inputLeftExtent) === 0) {
       startNode.isChangeStart = endNode.isChangeStart
       this.deleteNode(endNode)
-    } else if (!this.isBatchMode) {
+    } else if (!this.batchMode) {
       endNode.priority = this.generateRandom()
       this.bubbleNodeDown(endNode)
     }
@@ -80,7 +80,7 @@ export default class Patch {
         rightAncestor.newText = startNode.newText + rightAncestor.newText
       }
       this.deleteNode(startNode)
-    } else if (!this.isBatchMode) {
+    } else if (!this.batchMode) {
       startNode.priority = this.generateRandom()
       this.bubbleNodeDown(startNode)
     }
@@ -103,7 +103,9 @@ export default class Patch {
     if (this.batchMode) {
       this.splayNode(startNode)
       this.splayNode(endNode)
-      if (endNode.left !== startNode) this.rotateNodeRight(startNode)
+      if (startNode !== endNode && endNode.left !== startNode) {
+        this.rotateNodeRight(startNode)
+      }
     } else {
       startNode.priority = -1
       this.bubbleNodeUp(startNode)
@@ -128,10 +130,14 @@ export default class Patch {
     endNode.isChangeEnd = false
     endNode.newText = null
 
+    // document.write(`<div>after adjusting nodes(${formatPoint(inputStart)}, ${formatPoint(oldExtent)}, ${formatPoint(newExtent)})</div>`)
+    // document.write(this.toHTML())
+    // document.write('<hr>')
+
     let outputnewExtent = traversalDistance(endNode.outputLeftExtent, startNode.outputLeftExtent)
 
     if (startNode.isChangeEnd) {
-      if (!this.isBatchMode) {
+      if (!this.batchMode) {
         startNode.priority = this.generateRandom()
         this.bubbleNodeDown(startNode)
       }
@@ -140,7 +146,7 @@ export default class Patch {
     }
 
     if (endNode.isChangeStart) {
-      if (!this.isBatchMode) {
+      if (!this.batchMode) {
         endNode.priority = this.generateRandom()
         this.bubbleNodeDown(endNode)
       }

--- a/src/patch.js
+++ b/src/patch.js
@@ -72,7 +72,7 @@ export default class Patch {
     this.splayNode(endNode)
     if (options && options.metadata) endNode.metadata = options.metadata
 
-    if (startNode !== endNode && endNode.left !== startNode) {
+    if (endNode.left !== startNode) {
       this.rotateNodeRight(startNode)
     }
 
@@ -121,7 +121,7 @@ export default class Patch {
     let endNode = this.iterator.insertSpliceInputBoundary(inputOldEnd, false, oldExtentIsZero)
     this.splayNode(endNode)
 
-    if (startNode !== endNode && endNode.left !== startNode) {
+    if (endNode.left !== startNode) {
       this.rotateNodeRight(startNode)
     }
 

--- a/src/patch.js
+++ b/src/patch.js
@@ -38,10 +38,16 @@ export default class Patch {
     endNode.isChangeEnd = true
     if (options && options.metadata) endNode.metadata = options.metadata
 
-    startNode.priority = -1
-    this.bubbleNodeUp(startNode)
-    endNode.priority = -2
-    this.bubbleNodeUp(endNode)
+    if (this.batchMode) {
+      this.splayNode(startNode)
+      this.splayNode(endNode)
+      if (endNode.left !== startNode) this.rotateNodeRight(startNode)
+    } else {
+      startNode.priority = -1
+      this.bubbleNodeUp(startNode)
+      endNode.priority = -2
+      this.bubbleNodeUp(endNode)
+    }
 
     startNode.right = null
     startNode.inputExtent = startNode.inputLeftExtent
@@ -62,7 +68,7 @@ export default class Patch {
         && comparePoints(endNode.inputLeftExtent, startNode.inputLeftExtent) === 0) {
       startNode.isChangeStart = endNode.isChangeStart
       this.deleteNode(endNode)
-    } else {
+    } else if (!this.isBatchMode) {
       endNode.priority = this.generateRandom()
       this.bubbleNodeDown(endNode)
     }
@@ -74,7 +80,7 @@ export default class Patch {
         rightAncestor.newText = startNode.newText + rightAncestor.newText
       }
       this.deleteNode(startNode)
-    } else {
+    } else if (!this.isBatchMode) {
       startNode.priority = this.generateRandom()
       this.bubbleNodeDown(startNode)
     }
@@ -94,10 +100,16 @@ export default class Patch {
     let startNode = this.iterator.insertSpliceInputBoundary(inputStart, true, oldExtentIsZero)
     let endNode = this.iterator.insertSpliceInputBoundary(inputOldEnd, false, oldExtentIsZero)
 
-    startNode.priority = -1
-    this.bubbleNodeUp(startNode)
-    endNode.priority = -2
-    this.bubbleNodeUp(endNode)
+    if (this.batchMode) {
+      this.splayNode(startNode)
+      this.splayNode(endNode)
+      if (endNode.left !== startNode) this.rotateNodeRight(startNode)
+    } else {
+      startNode.priority = -1
+      this.bubbleNodeUp(startNode)
+      endNode.priority = -2
+      this.bubbleNodeUp(endNode)
+    }
 
     startNode.right = null
     startNode.inputExtent = startNode.inputLeftExtent
@@ -119,15 +131,19 @@ export default class Patch {
     let outputnewExtent = traversalDistance(endNode.outputLeftExtent, startNode.outputLeftExtent)
 
     if (startNode.isChangeEnd) {
-      startNode.priority = this.generateRandom()
-      this.bubbleNodeDown(startNode)
+      if (!this.isBatchMode) {
+        startNode.priority = this.generateRandom()
+        this.bubbleNodeDown(startNode)
+      }
     } else {
       this.deleteNode(startNode)
     }
 
     if (endNode.isChangeStart) {
-      endNode.priority = this.generateRandom()
-      this.bubbleNodeDown(endNode)
+      if (!this.isBatchMode) {
+        endNode.priority = this.generateRandom()
+        this.bubbleNodeDown(endNode)
+      }
     } else {
       this.deleteNode(endNode)
     }
@@ -182,6 +198,8 @@ export default class Patch {
           ancestor = ancestor.parent
         }
       }
+
+      if (this.batchMode) this.splayNode(node.parent)
     } else {
       this.root = null
     }

--- a/src/patch.js
+++ b/src/patch.js
@@ -22,6 +22,27 @@ export default class Patch {
   }
 
   rebalance () {
+    this.createBackbone()
+    this.createPerfectTree()
+  }
+
+  createBackbone () {
+    while (this.root != null) {
+      if (this.root.left != null) {
+        this.rotateNodeRight(pseudoRoot.left)
+      } else {
+        this.root = this.root.right
+      }
+    }
+  }
+
+  createPerfectTree () {
+    for (var i = 0; i < Math.log(this.nodesCount, 2); i++) {
+      this.rotateNodeLeft(this.root.right)
+      for (var j = 0; j < this.nodesCount / 2 - 1; j++) {
+        this.rotateNodeLeft(this.root.right)
+      }
+    }
   }
 
   spliceWithText (start, oldExtent, newText, options) {

--- a/src/patch.js
+++ b/src/patch.js
@@ -97,7 +97,7 @@ export default class Patch {
     }
 
     if (startNode.isChangeStart && startNode.isChangeEnd && this.combineChanges) {
-      let rightAncestor = this.bubbleNodeDown(startNode) || endNode
+      let rightAncestor = this.bubbleNodeDown(startNode) || this.root
       if (startNode.newText != null) {
         rightAncestor.newText = startNode.newText + rightAncestor.newText
       }

--- a/src/patch.js
+++ b/src/patch.js
@@ -33,14 +33,14 @@ export default class Patch {
 
     let startNode = this.iterator.insertSpliceBoundary(outputStart)
     startNode.isChangeStart = true
+    if (this.batchMode) this.splayNode(startNode)
 
     let endNode = this.iterator.insertSpliceBoundary(outputOldEnd, startNode)
     endNode.isChangeEnd = true
+    if (this.batchMode) this.splayNode(endNode)
     if (options && options.metadata) endNode.metadata = options.metadata
 
     if (this.batchMode) {
-      this.splayNode(startNode)
-      this.splayNode(endNode)
       if (startNode !== endNode && endNode.left !== startNode) this.rotateNodeRight(startNode)
     } else {
       startNode.priority = -1
@@ -98,14 +98,12 @@ export default class Patch {
     let inputNewEnd = traverse(inputStart, newExtent)
 
     let startNode = this.iterator.insertSpliceInputBoundary(inputStart, true, oldExtentIsZero)
+    if (this.batchMode) this.splayNode(startNode)
     let endNode = this.iterator.insertSpliceInputBoundary(inputOldEnd, false, oldExtentIsZero)
+    if (this.batchMode) this.splayNode(endNode)
 
     if (this.batchMode) {
-      this.splayNode(startNode)
-      this.splayNode(endNode)
-      if (startNode !== endNode && endNode.left !== startNode) {
-        this.rotateNodeRight(startNode)
-      }
+      if (startNode !== endNode && endNode.left !== startNode) this.rotateNodeRight(startNode)
     } else {
       startNode.priority = -1
       this.bubbleNodeUp(startNode)

--- a/src/patch.js
+++ b/src/patch.js
@@ -45,8 +45,8 @@ export default class Patch {
     let m = Math.pow(2, Math.floor(Math.log2(n + 1))) - 1
     this.performRebalancingRotations(n - m)
     while (m > 1) {
-      m /= 2
-      this.performRebalancingRotations(m - 1)
+      m = Math.floor(m / 2)
+      this.performRebalancingRotations(m)
     }
   }
 

--- a/src/patch.js
+++ b/src/patch.js
@@ -68,7 +68,9 @@ export default class Patch {
         && comparePoints(endNode.inputLeftExtent, startNode.inputLeftExtent) === 0) {
       startNode.isChangeStart = endNode.isChangeStart
       this.deleteNode(endNode)
-    } else if (!this.batchMode) {
+    } else if (this.batchMode) {
+      this.rotateNodeRight(startNode)
+    } else {
       endNode.priority = this.generateRandom()
       this.bubbleNodeDown(endNode)
     }
@@ -119,7 +121,7 @@ export default class Patch {
     startNode.isChangeStart = false
 
     let outputStart = startNode.outputLeftExtent
-    let outputoldExtent = traversalDistance(endNode.outputLeftExtent, startNode.outputLeftExtent)
+    let outputOldExtent = traversalDistance(endNode.outputLeftExtent, startNode.outputLeftExtent)
 
     let endNodeInputRightExtent = traversalDistance(endNode.inputExtent, endNode.inputLeftExtent)
     let endNodeOutputRightExtent = traversalDistance(endNode.outputExtent, endNode.outputLeftExtent)
@@ -130,11 +132,7 @@ export default class Patch {
     endNode.isChangeEnd = false
     endNode.newText = null
 
-    // document.write(`<div>after adjusting nodes(${formatPoint(inputStart)}, ${formatPoint(oldExtent)}, ${formatPoint(newExtent)})</div>`)
-    // document.write(this.toHTML())
-    // document.write('<hr>')
-
-    let outputnewExtent = traversalDistance(endNode.outputLeftExtent, startNode.outputLeftExtent)
+    let outputNewExtent = traversalDistance(endNode.outputLeftExtent, startNode.outputLeftExtent)
 
     if (startNode.isChangeEnd) {
       if (!this.batchMode) {
@@ -156,8 +154,8 @@ export default class Patch {
 
     return {
       start: outputStart,
-      oldExtent: outputoldExtent,
-      newExtent: outputnewExtent
+      oldExtent: outputOldExtent,
+      newExtent: outputNewExtent
     }
   }
 

--- a/src/patch.js
+++ b/src/patch.js
@@ -23,25 +23,41 @@ export default class Patch {
 
   rebalance () {
     this.createBackbone()
-    this.createPerfectTree()
+    this.createBalancedTree()
   }
 
   createBackbone () {
-    while (this.root != null) {
-      if (this.root.left != null) {
-        this.rotateNodeRight(pseudoRoot.left)
+    let pseudoRoot = this.root
+    while (pseudoRoot != null) {
+      let leftChild = pseudoRoot.left
+      let rightChild = pseudoRoot.right
+      if (leftChild != null) {
+        this.rotateNodeRight(leftChild)
+        pseudoRoot = leftChild
       } else {
-        this.root = this.root.right
+        pseudoRoot = rightChild
       }
     }
   }
 
-  createPerfectTree () {
-    for (var i = 0; i < Math.log(this.nodesCount, 2); i++) {
-      this.rotateNodeLeft(this.root.right)
-      for (var j = 0; j < this.nodesCount / 2 - 1; j++) {
-        this.rotateNodeLeft(this.root.right)
-      }
+  createBalancedTree() {
+    let n = this.nodesCount
+    let m = Math.pow(2, Math.floor(Math.log2(n + 1))) - 1
+    this.performLeftRotations(n - m)
+    while (m > 1) {
+      m /= 2
+      this.performLeftRotations(m - 1)
+    }
+  }
+
+  performLeftRotations (count) {
+    let root = this.root
+    for (var i = 0; i < count; i++) {
+      if (root == null) return
+      let rightChild = root.right
+      if (rightChild == null) return
+      root = rightChild.right
+      this.rotateNodeLeft(rightChild)
     }
   }
 

--- a/src/patch.js
+++ b/src/patch.js
@@ -43,14 +43,14 @@ export default class Patch {
   createBalancedTree() {
     let n = this.nodesCount
     let m = Math.pow(2, Math.floor(Math.log2(n + 1))) - 1
-    this.performLeftRotations(n - m)
+    this.performRebalancingRotations(n - m)
     while (m > 1) {
       m /= 2
-      this.performLeftRotations(m - 1)
+      this.performRebalancingRotations(m - 1)
     }
   }
 
-  performLeftRotations (count) {
+  performRebalancingRotations (count) {
     let root = this.root
     for (var i = 0; i < count; i++) {
       if (root == null) return

--- a/src/patch.js
+++ b/src/patch.js
@@ -13,11 +13,15 @@ export default class Patch {
     }
 
     this.root = null
+    this.nodesCount = 0
     this.iterator = this.buildIterator()
   }
 
   buildIterator () {
     return new Iterator(this)
+  }
+
+  rebalance () {
   }
 
   spliceWithText (start, oldExtent, newText, options) {
@@ -207,6 +211,8 @@ export default class Patch {
     } else {
       this.root = null
     }
+
+    this.nodesCount--
   }
 
   bubbleNodeUp (node) {

--- a/src/patch.js
+++ b/src/patch.js
@@ -15,11 +15,11 @@ export default class Patch {
   }
 
   rebalance () {
-    this.createBackbone()
-    this.createBalancedTree()
+    this.transformTreeToVine()
+    this.transformVineToBalancedTree()
   }
 
-  createBackbone () {
+  transformTreeToVine () {
     let pseudoRoot = this.root
     while (pseudoRoot) {
       if (pseudoRoot.left) {
@@ -31,7 +31,7 @@ export default class Patch {
     }
   }
 
-  createBalancedTree() {
+  transformVineToBalancedTree() {
     let n = this.nodesCount
     let m = Math.pow(2, Math.floor(Math.log2(n + 1))) - 1
     this.performRebalancingRotations(n - m)

--- a/test/patch.test.js
+++ b/test/patch.test.js
@@ -64,17 +64,17 @@ describe('Patch', function () {
         if (random(10) < 2) { // 20% splice input
           let {start: inputStart, oldExtent, newExtent, newText} = input.performRandomSplice()
           let outputStart = patch.translateInputPosition(inputStart)
-          let outputoldExtent = traversalDistance(
+          let outputOldExtent = traversalDistance(
             patch.translateInputPosition(traverse(inputStart, oldExtent)),
             outputStart
           )
-          output.splice(outputStart, outputoldExtent, newText)
+          output.splice(outputStart, outputOldExtent, newText)
           let result = patch.spliceInput(inputStart, oldExtent, newExtent)
           // document.write(`<div>after spliceInput(${formatPoint(inputStart)}, ${formatPoint(oldExtent)}, ${formatPoint(newExtent)}, ${newText})</div>`)
           // document.write(patch.toHTML())
           // document.write('<hr>')
           assert.deepEqual(result.start, outputStart, seedMessage)
-          assert.deepEqual(result.oldExtent, outputoldExtent, seedMessage)
+          assert.deepEqual(result.oldExtent, outputOldExtent, seedMessage)
           assert.deepEqual(result.newExtent, newExtent, seedMessage)
         } else { // 80% normal splice
           let {start, oldExtent, newExtent, newText} = output.performRandomSplice()

--- a/test/patch.test.js
+++ b/test/patch.test.js
@@ -85,6 +85,9 @@ describe('Patch', function () {
           // document.write('<hr>')
         }
 
+        let shouldRebalance = Boolean(random(2))
+        if (batchMode && shouldRebalance) patch.rebalance()
+
         verifyPatch(patch, input.clone(), output, random, seedMessage)
       }
     }

--- a/test/patch.test.js
+++ b/test/patch.test.js
@@ -48,7 +48,7 @@ describe('Patch', function () {
     assert.deepEqual(iterator.getMetadata(), {b: 2})
   })
 
-  it.only('correctly records random splices', function () {
+  it('correctly records random splices', function () {
     this.timeout(Infinity)
 
     for (let i = 0; i < 1000; i++) {

--- a/test/patch.test.js
+++ b/test/patch.test.js
@@ -58,7 +58,8 @@ describe('Patch', function () {
       let input = new TestDocument(seed)
       let output = input.clone()
       let combineChanges = Boolean(random(2))
-      let patch = new Patch({seed, combineChanges})
+      let batchMode = Boolean(random(2))
+      let patch = new Patch({seed, combineChanges, batchMode})
 
       for (let j = 0; j < 10; j++) {
         if (random(10) < 2) { // 20% splice input

--- a/test/patch.test.js
+++ b/test/patch.test.js
@@ -69,10 +69,10 @@ describe('Patch', function () {
             outputStart
           )
           output.splice(outputStart, outputoldExtent, newText)
+          let result = patch.spliceInput(inputStart, oldExtent, newExtent)
           // document.write(`<div>after spliceInput(${formatPoint(inputStart)}, ${formatPoint(oldExtent)}, ${formatPoint(newExtent)}, ${newText})</div>`)
           // document.write(patch.toHTML())
           // document.write('<hr>')
-          let result = patch.spliceInput(inputStart, oldExtent, newExtent)
           assert.deepEqual(result.start, outputStart, seedMessage)
           assert.deepEqual(result.oldExtent, outputoldExtent, seedMessage)
           assert.deepEqual(result.newExtent, newExtent, seedMessage)

--- a/test/patch.test.js
+++ b/test/patch.test.js
@@ -58,8 +58,7 @@ describe('Patch', function () {
       let input = new TestDocument(seed)
       let output = input.clone()
       let combineChanges = Boolean(random(2))
-      let batchMode = Boolean(random(2))
-      let patch = new Patch({seed, combineChanges, batchMode})
+      let patch = new Patch({seed, combineChanges})
 
       for (let j = 0; j < 10; j++) {
         if (random(10) < 2) { // 20% splice input
@@ -86,7 +85,7 @@ describe('Patch', function () {
         }
 
         let shouldRebalance = Boolean(random(2))
-        if (batchMode && shouldRebalance) patch.rebalance()
+        if (shouldRebalance) patch.rebalance()
 
         verifyPatch(patch, input.clone(), output, random, seedMessage)
       }

--- a/test/patch.test.js
+++ b/test/patch.test.js
@@ -58,7 +58,8 @@ describe('Patch', function () {
       let input = new TestDocument(seed)
       let output = input.clone()
       let combineChanges = Boolean(random(2))
-      let patch = new Patch({seed, combineChanges})
+      let batchMode = Boolean(random(2))
+      let patch = new Patch({seed, combineChanges, batchMode})
 
       for (let j = 0; j < 10; j++) {
         if (random(10) < 2) { // 20% splice input
@@ -85,7 +86,7 @@ describe('Patch', function () {
         }
 
         let shouldRebalance = Boolean(random(2))
-        if (shouldRebalance) patch.rebalance()
+        if (batchMode && shouldRebalance) patch.rebalance()
 
         verifyPatch(patch, input.clone(), output, random, seedMessage)
       }

--- a/test/patch.test.js
+++ b/test/patch.test.js
@@ -48,7 +48,7 @@ describe('Patch', function () {
     assert.deepEqual(iterator.getMetadata(), {b: 2})
   })
 
-  it('correctly records random splices', function () {
+  it.only('correctly records random splices', function () {
     this.timeout(Infinity)
 
     for (let i = 0; i < 1000; i++) {


### PR DESCRIPTION
With this PR, when passing `{batchMode: true}` to `Patch` constructor, a [splay tree](https://en.wikipedia.org/wiki/Splay_tree) will be used as the underlying data structure for managing changes.
#### Benchmarks

![screen shot 2016-02-04 at 11 40 13](https://cloud.githubusercontent.com/assets/482957/12812745/16c257a2-cb34-11e5-9a96-1a69ef527f5b.png)

_(Benchmarks generated using https://gist.github.com/as-cii/3f020dd5789f9c649bc8. Copy the content of that gist and then execute `pbpaste | git apply && npm run tdd` in your terminal)_

As you can notice, the two implementations have similar performance except for the case of non-overlapping sequential insertions, where the splay tree is ~ 3x faster. 

Another case where the splay tree outperforms the treap is when repeatedly splicing in a ordered manner (e.g. splice one character in each row, splice one more character after the previous one in the same rows, etc.). By calling `balance` on the patch after each mass insertion, we manage to make the splay tree ~ `125ms` faster.
### Manual Testing

In practice, when inserting a single character on ~ 3000 lines, the improvement is even more noticeable.

|  |  |
| --- | --- |
| Before | ![screen shot 2016-02-03 at 04 57 50](https://cloud.githubusercontent.com/assets/482957/12772848/e9faf106-ca35-11e5-9ca5-b5010949312a.png) |
| After | ![screen shot 2016-02-03 at 04 57 31](https://cloud.githubusercontent.com/assets/482957/12772847/e9c540e2-ca35-11e5-9dd3-fdbedbafb894.png) |

Splay trees in this case are 8x faster (also, please note that the total time showed here is the cost of maintaining two patches, as I ran the tests with https://github.com/atom/text-buffer/pull/127).

When inserting multiple characters, splicing into those two patches is only 2x faster, but I think it's because of the `stoppedChangingPatch` (which may be acting similarly to the automated benchmark above, "Repeated Sequential Non-Overlapping Insertions"), so DSW should help here as well.

Overall, I am pretty happy with the results and I'd love to hear what you guys think about this. Also, before merging this PR, I'd like to experiment with a couple of things:
- [x] Implement a `balance` function that uses DSW and re-assess performance.

/cc: @maxbrunsfeld @nathansobo @kuychaco for :eyes: :racehorse: :racehorse: :racehorse: 
