### PR TITLE
Make `pushToAncestorStacks` faster

### DIFF
--- a/src/iterator.js
+++ b/src/iterator.js
@@ -11,14 +11,14 @@ export default class Iterator {
     this.leftAncestor = null
     this.leftAncestorInputPosition = ZERO_POINT
     this.leftAncestorOutputPosition = ZERO_POINT
-    this.leftAncestorStack = [null]
+    this.leftAncestorStack = []
     this.leftAncestorInputPositionStack = [ZERO_POINT]
     this.leftAncestorOutputPositionStack = [ZERO_POINT]
 
     this.rightAncestor = null
     this.rightAncestorInputPosition = INFINITY_POINT
     this.rightAncestorOutputPosition = INFINITY_POINT
-    this.rightAncestorStack = [null]
+    this.rightAncestorStack = []
     this.rightAncestorInputPositionStack = [INFINITY_POINT]
     this.rightAncestorOutputPositionStack = [INFINITY_POINT]
 


### PR DESCRIPTION
Apparently, v8 cannot optimize this function because the array stack is heterogeneous (i.e. it has a `null` object as its first element, and `Node`s as the subsequent ones).

Since popping from the array returns `null` anyways, we can remove those `null` elements and let v8 optimize the function.

Here's the improvement on 5000 splices:

|  |  |
| --- | --- |
| Before | ![before](https://cloud.githubusercontent.com/assets/482957/12813844/f0134b64-cb3a-11e5-8449-59377c4d0ea4.png) |
| After | ![after](https://cloud.githubusercontent.com/assets/482957/12813797/adcb16ce-cb3a-11e5-9a64-3387b54d35f0.png) |

/cc: @maxbrunsfeld @nathansobo @kuychaco 
