### PR TITLE
Include input changes in `Patch.prototype.getChanges()`

### DIFF
--- a/src/iterator.js
+++ b/src/iterator.js
@@ -51,13 +51,17 @@ export default class Iterator {
     while (this.moveToSuccessor()) {
       if (!this.inChange()) continue
 
-      changes.push({
+      let change = {
         oldStart: this.inputStart,
         newStart: this.outputStart,
         oldExtent: traversalDistance(this.inputEnd, this.inputStart),
         newExtent: traversalDistance(this.outputEnd, this.outputStart),
-        newText: this.currentNode.newText
-      })
+      }
+      if (this.currentNode.newText != null) {
+        change.newText = this.currentNode.newText
+      }
+
+      changes.push(change)
     }
 
     return changes

--- a/src/iterator.js
+++ b/src/iterator.js
@@ -229,11 +229,7 @@ export default class Iterator {
       }
       this.ascend()
 
-      if (this.currentNode) {
-        return true
-      } else {
-        return false
-      }
+      return this.currentNode != null
     }
   }
 

--- a/src/iterator.js
+++ b/src/iterator.js
@@ -28,7 +28,7 @@ export default class Iterator {
     this.setCurrentNode(this.patch.root)
   }
 
-  rewind () {
+  moveToBeginning () {
     this.reset()
 
     while (this.currentNode && this.currentNode.left) {
@@ -36,7 +36,7 @@ export default class Iterator {
     }
   }
 
-  forward () {
+  moveToEnd () {
     this.reset()
 
     while (this.currentNode && this.currentNode.right) {
@@ -45,7 +45,7 @@ export default class Iterator {
   }
 
   getChanges () {
-    this.rewind()
+    this.moveToBeginning()
 
     let changes = []
     while (this.moveToSuccessor()) {
@@ -66,8 +66,8 @@ export default class Iterator {
     return changes
   }
 
-  getChangesInReverse () {
-    this.forward()
+  getInputChanges () {
+    this.moveToEnd()
 
     let changes = []
     if (this.inChange()) {
@@ -236,21 +236,16 @@ export default class Iterator {
       }
       return true
     } else {
-      let previousInputStart = this.inputStart
-      let previousOutputStart = this.outputStart
-
       while (this.currentNode.parent && this.currentNode.parent.left === this.currentNode) {
         this.ascend()
       }
       this.ascend()
 
-      if (!this.currentNode) { // advanced off left edge of tree
-        this.inputStart = ZERO_POINT
-        this.outputStart = ZERO_POINT
-        this.inputEnd = previousInputStart
-        this.outputEnd = previousOutputStart
+      if (this.currentNode) {
+        return true
+      } else {
+        return false
       }
-      return true
     }
   }
 

--- a/src/iterator.js
+++ b/src/iterator.js
@@ -36,6 +36,14 @@ export default class Iterator {
     }
   }
 
+  forward () {
+    this.reset()
+
+    while (this.currentNode && this.currentNode.right) {
+      this.descendRight()
+    }
+  }
+
   getChanges () {
     this.rewind()
 
@@ -53,6 +61,32 @@ export default class Iterator {
         }
         changes.push(change)
       }
+    }
+
+    return changes
+  }
+
+  getChangesInReverse () {
+    this.forward()
+
+    let changes = []
+    if (this.inChange()) {
+      changes.push({
+        start: this.inputStart,
+        oldExtent: traversalDistance(this.inputEnd, this.inputStart),
+        newExtent: traversalDistance(this.outputEnd, this.outputStart),
+        newText: this.currentNode.newText
+      })
+    }
+    while (this.moveToPredecessor()) {
+      if (!this.inChange()) continue
+
+      changes.push({
+        start: this.inputStart,
+        oldExtent: traversalDistance(this.inputEnd, this.inputStart),
+        newExtent: traversalDistance(this.outputEnd, this.outputStart),
+        newText: this.currentNode.newText
+      })
     }
 
     return changes
@@ -187,6 +221,34 @@ export default class Iterator {
         this.outputStart = previousOutputEnd
         this.inputEnd = INFINITY_POINT
         this.outputEnd = INFINITY_POINT
+      }
+      return true
+    }
+  }
+
+  moveToPredecessor () {
+    if (!this.currentNode) return false
+
+    if (this.currentNode.left) {
+      this.descendLeft()
+      while (this.currentNode.right) {
+        this.descendRight()
+      }
+      return true
+    } else {
+      let previousInputStart = this.inputStart
+      let previousOutputStart = this.outputStart
+
+      while (this.currentNode.parent && this.currentNode.parent.left === this.currentNode) {
+        this.ascend()
+      }
+      this.ascend()
+
+      if (!this.currentNode) { // advanced off left edge of tree
+        this.inputStart = ZERO_POINT
+        this.outputStart = ZERO_POINT
+        this.inputEnd = previousInputStart
+        this.outputEnd = previousOutputStart
       }
       return true
     }

--- a/src/iterator.js
+++ b/src/iterator.js
@@ -49,18 +49,14 @@ export default class Iterator {
 
     let changes = []
     while (this.moveToSuccessor()) {
-      let inChange = this.inChange()
-      if (inChange) {
-        let change = {
-          start: this.outputStart,
-          oldExtent: traversalDistance(this.inputEnd, this.inputStart),
-          newExtent: traversalDistance(this.outputEnd, this.outputStart),
-        }
-        if (this.currentNode.newText != null) {
-          change.newText = this.currentNode.newText
-        }
-        changes.push(change)
-      }
+      if (!this.inChange()) continue
+
+      changes.push({
+        start: this.outputStart,
+        oldExtent: traversalDistance(this.inputEnd, this.inputStart),
+        newExtent: traversalDistance(this.outputEnd, this.outputStart),
+        newText: this.currentNode.newText
+      })
     }
 
     return changes

--- a/src/iterator.js
+++ b/src/iterator.js
@@ -52,8 +52,8 @@ export default class Iterator {
       if (!this.inChange()) continue
 
       changes.push({
-        inputStart: this.inputStart,
-        outputStart: this.outputStart,
+        oldStart: this.inputStart,
+        newStart: this.outputStart,
         oldExtent: traversalDistance(this.inputEnd, this.inputStart),
         newExtent: traversalDistance(this.outputEnd, this.outputStart),
         newText: this.currentNode.newText

--- a/src/iterator.js
+++ b/src/iterator.js
@@ -70,15 +70,7 @@ export default class Iterator {
     this.moveToEnd()
 
     let changes = []
-    if (this.inChange()) {
-      changes.push({
-        start: this.inputStart,
-        oldExtent: traversalDistance(this.inputEnd, this.inputStart),
-        newExtent: traversalDistance(this.outputEnd, this.outputStart),
-        newText: this.currentNode.newText
-      })
-    }
-    while (this.moveToPredecessor()) {
+    do {
       if (!this.inChange()) continue
 
       changes.push({
@@ -87,7 +79,7 @@ export default class Iterator {
         newExtent: traversalDistance(this.outputEnd, this.outputStart),
         newText: this.currentNode.newText
       })
-    }
+    } while (this.moveToPredecessor())
 
     return changes
   }

--- a/src/iterator.js
+++ b/src/iterator.js
@@ -52,30 +52,13 @@ export default class Iterator {
       if (!this.inChange()) continue
 
       changes.push({
-        start: this.outputStart,
+        inputStart: this.inputStart,
+        outputStart: this.outputStart,
         oldExtent: traversalDistance(this.inputEnd, this.inputStart),
         newExtent: traversalDistance(this.outputEnd, this.outputStart),
         newText: this.currentNode.newText
       })
     }
-
-    return changes
-  }
-
-  getInputChanges () {
-    this.moveToEnd()
-
-    let changes = []
-    do {
-      if (!this.inChange()) continue
-
-      changes.push({
-        start: this.inputStart,
-        oldExtent: traversalDistance(this.inputEnd, this.inputStart),
-        newExtent: traversalDistance(this.outputEnd, this.outputStart),
-        newText: this.currentNode.newText
-      })
-    } while (this.moveToPredecessor())
 
     return changes
   }

--- a/src/patch.js
+++ b/src/patch.js
@@ -111,7 +111,7 @@ export default class Patch {
       let change = {start: translate(start, accumulatingDelta), oldExtent, newExtent}
       accumulatingDelta = traverse(accumulatingDelta, translationDistance(oldExtent, newExtent))
       return change
-    })
+    }).reverse()
   }
 
   deleteNode (node) {

--- a/src/patch.js
+++ b/src/patch.js
@@ -1,4 +1,4 @@
-import {ZERO_POINT, traverse, traversalDistance, translate, translationDistance, min as minPoint, isZero as isZeroPoint, compare as comparePoints} from './point-helpers'
+import {ZERO_POINT, traverse, foo, traversalDistance, translate, translationDistance, min as minPoint, isZero as isZeroPoint, compare as comparePoints} from './point-helpers'
 import {getExtent} from './text-helpers'
 import Iterator from './iterator'
 
@@ -106,12 +106,7 @@ export default class Patch {
   }
 
   getChangesInReverse () {
-    let accumulatingDelta = {row: 0, column: 0}
-    return this.iterator.getChanges().map(function ({start, oldExtent, newExtent}) {
-      let change = {start: translate(start, accumulatingDelta), oldExtent, newExtent}
-      accumulatingDelta = traverse(accumulatingDelta, translationDistance(oldExtent, newExtent))
-      return change
-    }).reverse()
+    return this.iterator.getChangesInReverse()
   }
 
   deleteNode (node) {

--- a/src/patch.js
+++ b/src/patch.js
@@ -3,10 +3,10 @@ import {getExtent} from './text-helpers'
 import Iterator from './iterator'
 
 export default class Patch {
-  static composeChanges (patchesChanges) {
+  static compose (patches) {
     let composedPatch = new Patch()
-    for (let index = 0; index < patchesChanges.length; index++) {
-      let changes = patchesChanges[index]
+    for (let index = 0; index < patches.length; index++) {
+      let changes = patches[index].getChanges()
       if ((index & 1) === 0) { // flip
         for (let i = 0; i < changes.length; i++) {
           let {newStart, oldExtent, newExtent, newText} = changes[i]
@@ -27,6 +27,7 @@ export default class Patch {
     this.root = null
     this.nodesCount = 0
     this.iterator = this.buildIterator()
+    this.cachedChanges = null
   }
 
   buildIterator () {
@@ -119,10 +120,16 @@ export default class Patch {
       }
       this.deleteNode(startNode)
     }
+
+    this.cachedChanges = null
   }
 
   getChanges () {
-    return this.iterator.getChanges()
+    if (this.cachedChanges == null) {
+      this.cachedChanges = this.iterator.getChanges()
+    }
+
+    return this.cachedChanges
   }
 
   deleteNode (node) {

--- a/src/patch.js
+++ b/src/patch.js
@@ -1,4 +1,4 @@
-import {ZERO_POINT, traverse, traversalDistance, min as minPoint, isZero as isZeroPoint, compare as comparePoints} from './point-helpers'
+import {ZERO_POINT, traverse, traversalDistance, translate, translationDistance, min as minPoint, isZero as isZeroPoint, compare as comparePoints} from './point-helpers'
 import {getExtent} from './text-helpers'
 import Iterator from './iterator'
 
@@ -103,6 +103,15 @@ export default class Patch {
 
   getChanges () {
     return this.iterator.getChanges()
+  }
+
+  getChangesInReverse () {
+    let accumulatingDelta = {row: 0, column: 0}
+    return this.iterator.getChanges().map(function ({start, oldExtent, newExtent}) {
+      let change = {start: translate(start, accumulatingDelta), oldExtent, newExtent}
+      accumulatingDelta = traverse(accumulatingDelta, translationDistance(oldExtent, newExtent))
+      return change
+    })
   }
 
   deleteNode (node) {

--- a/src/patch.js
+++ b/src/patch.js
@@ -105,8 +105,8 @@ export default class Patch {
     return this.iterator.getChanges()
   }
 
-  getChangesInReverse () {
-    return this.iterator.getChangesInReverse()
+  getInputChanges () {
+    return this.iterator.getInputChanges()
   }
 
   deleteNode (node) {

--- a/src/patch.js
+++ b/src/patch.js
@@ -53,21 +53,21 @@ export default class Patch {
     }
   }
 
-  spliceWithText (start, oldExtent, newText, options) {
-    this.splice(start, oldExtent, getExtent(newText), {text: newText})
+  spliceWithText (newStart, oldExtent, newText, options) {
+    this.splice(newStart, oldExtent, getExtent(newText), {text: newText})
   }
 
-  splice (outputStart, oldExtent, newExtent, options) {
+  splice (newStart, oldExtent, newExtent, options) {
     if (isZeroPoint(oldExtent) && isZeroPoint(newExtent)) return
 
-    let outputOldEnd = traverse(outputStart, oldExtent)
-    let outputNewEnd = traverse(outputStart, newExtent)
+    let oldEnd = traverse(newStart, oldExtent)
+    let newEnd = traverse(newStart, newExtent)
 
-    let startNode = this.iterator.insertSpliceBoundary(outputStart)
+    let startNode = this.iterator.insertSpliceBoundary(newStart)
     startNode.isChangeStart = true
     this.splayNode(startNode)
 
-    let endNode = this.iterator.insertSpliceBoundary(outputOldEnd, startNode)
+    let endNode = this.iterator.insertSpliceBoundary(oldEnd, startNode)
     endNode.isChangeEnd = true
     this.splayNode(endNode)
     if (endNode.left !== startNode) this.rotateNodeRight(startNode)
@@ -76,8 +76,8 @@ export default class Patch {
     startNode.inputExtent = startNode.inputLeftExtent
     startNode.outputExtent = startNode.outputLeftExtent
 
-    endNode.outputExtent = traverse(outputNewEnd, traversalDistance(endNode.outputExtent, endNode.outputLeftExtent))
-    endNode.outputLeftExtent = outputNewEnd
+    endNode.outputExtent = traverse(newEnd, traversalDistance(endNode.outputExtent, endNode.outputLeftExtent))
+    endNode.outputLeftExtent = newEnd
     endNode.newText = options && options.text
 
     if (endNode.isChangeStart) {

--- a/src/patch.js
+++ b/src/patch.js
@@ -3,6 +3,28 @@ import {getExtent} from './text-helpers'
 import Iterator from './iterator'
 
 export default class Patch {
+  static composeChanges (patchesChanges) {
+    let index = 0
+    let composedPatch = new Patch()
+    for (let changes of patchesChanges) {
+      if ((index & 1) === 0) { // flip
+        for (var i = 0; i < changes.length; i++) {
+          let {newStart, oldExtent, newExtent, newText} = changes[i]
+          composedPatch.splice(newStart, oldExtent, newExtent, {text: newText})
+        }
+      } else { // flop
+        for (var i = changes.length - 1; i >= 0; i--) {
+          let {oldStart, oldExtent, newExtent, newText} = changes[i]
+          composedPatch.splice(oldStart, oldExtent, newExtent, {text: newText})
+        }
+      }
+
+      index++
+    }
+
+    return composedPatch.getChanges()
+  }
+
   constructor (params = {}) {
     this.root = null
     this.nodesCount = 0

--- a/src/patch.js
+++ b/src/patch.js
@@ -4,22 +4,20 @@ import Iterator from './iterator'
 
 export default class Patch {
   static composeChanges (patchesChanges) {
-    let index = 0
     let composedPatch = new Patch()
-    for (let changes of patchesChanges) {
+    for (let index = 0; index < patchesChanges.length; index++) {
+      let changes = patchesChanges[index]
       if ((index & 1) === 0) { // flip
-        for (var i = 0; i < changes.length; i++) {
+        for (let i = 0; i < changes.length; i++) {
           let {newStart, oldExtent, newExtent, newText} = changes[i]
           composedPatch.splice(newStart, oldExtent, newExtent, {text: newText})
         }
       } else { // flop
-        for (var i = changes.length - 1; i >= 0; i--) {
+        for (let i = changes.length - 1; i >= 0; i--) {
           let {oldStart, oldExtent, newExtent, newText} = changes[i]
           composedPatch.splice(oldStart, oldExtent, newExtent, {text: newText})
         }
       }
-
-      index++
     }
 
     return composedPatch.getChanges()

--- a/src/patch.js
+++ b/src/patch.js
@@ -1,4 +1,4 @@
-import {ZERO_POINT, traverse, foo, traversalDistance, translate, translationDistance, min as minPoint, isZero as isZeroPoint, compare as comparePoints} from './point-helpers'
+import {ZERO_POINT, traverse, traversalDistance, min as minPoint, isZero as isZeroPoint, compare as comparePoints} from './point-helpers'
 import {getExtent} from './text-helpers'
 import Iterator from './iterator'
 

--- a/src/patch.js
+++ b/src/patch.js
@@ -105,10 +105,6 @@ export default class Patch {
     return this.iterator.getChanges()
   }
 
-  getInputChanges () {
-    return this.iterator.getInputChanges()
-  }
-
   deleteNode (node) {
     this.bubbleNodeDown(node)
     if (node.parent) {

--- a/src/point-helpers.js
+++ b/src/point-helpers.js
@@ -13,6 +13,10 @@ export function isZero (point) {
   return (point.row === 0 && point.column === 0)
 }
 
+export function isInfinity (point) {
+  return (point.row === INFINITY_POINT || point.column === Infinity)
+}
+
 export function min (a, b) {
   if (compare(a, b) <= 0) {
     return a

--- a/src/point-helpers.js
+++ b/src/point-helpers.js
@@ -21,29 +21,6 @@ export function min (a, b) {
   }
 }
 
-export function translate (start, distance) {
-  return {
-    row: start.row + distance.row,
-    column: start.column + distance.column
-  }
-}
-
-export function foo (start, distance) {
-  if (start.row === distance.row) {
-    return {row: start.row, column: start.column + distance.column}
-  } else {
-    return {row: start.row + distance.row, column: 0}
-  }
-}
-
-export function translationDistance (end, start) {
-  if (end.row === start.row) {
-    return {row: 0, column: end.column - start.column}
-  } else {
-    return {row: end.row - start.row, column: 0}
-  }
-}
-
 export function traverse (start, distance) {
   if (distance.row === 0) {
     return {

--- a/src/point-helpers.js
+++ b/src/point-helpers.js
@@ -21,6 +21,21 @@ export function min (a, b) {
   }
 }
 
+export function translate (start, distance) {
+  return {
+    row: start.row + distance.row,
+    column: start.column + distance.column
+  }
+}
+
+export function translationDistance (end, start) {
+  if (end.row === start.row) {
+    return {row: 0, column: end.column - start.column}
+  } else {
+    return {row: end.row - start.row, column: 0}
+  }
+}
+
 export function traverse (start, distance) {
   if (distance.row === 0) {
     return {

--- a/src/point-helpers.js
+++ b/src/point-helpers.js
@@ -28,6 +28,14 @@ export function translate (start, distance) {
   }
 }
 
+export function foo (start, distance) {
+  if (start.row === distance.row) {
+    return {row: start.row, column: start.column + distance.column}
+  } else {
+    return {row: start.row + distance.row, column: 0}
+  }
+}
+
 export function translationDistance (end, start) {
   if (end.row === start.row) {
     return {row: 0, column: end.column - start.column}

--- a/test/helpers/add-to-html-methods.js
+++ b/test/helpers/add-to-html-methods.js
@@ -23,7 +23,7 @@ Node.prototype.toHTML = function (leftAncestorInputPosition = ZERO_POINT, leftAn
   let changeEnd = this.isChangeEnd ? ' &lt;&lt;' : ''
   let inputPosition = traverse(leftAncestorInputPosition, this.inputLeftExtent)
   let outputPosition = traverse(leftAncestorOutputPosition, this.outputLeftExtent)
-  s += '<td colspan="2">' + ' {' + JSON.stringify(this.newText)  + '} ' + changeEnd + formatPoint(inputPosition) + ' / ' + formatPoint(outputPosition) + changeStart + '</td>'
+  s += '<td colspan="2">' + `[${this.id}]` + ' {' + JSON.stringify(this.newText)  + '} ' + changeEnd + formatPoint(inputPosition) + ' / ' + formatPoint(outputPosition) + changeStart + '</td>'
   s += '</tr>'
 
   if (this.left || this.right) {

--- a/test/helpers/test-document.js
+++ b/test/helpers/test-document.js
@@ -28,13 +28,15 @@ export default class TestDocument {
     let endRow = Math.min(end.row, this.lines.length - 1)
     if (start.row === endRow) {
       return this.lines[start.row].substring(start.column, end.column)
-    } else {
+    } else if (!pointHelpers.isInfinity(start)) {
       let text = this.lines[start.row].substring(start.column) + '\n'
       for (let row = start.row + 1; row < endRow; row++) {
         text += this.lines[row] + '\n'
       }
       text += this.lines[endRow].substring(0, end.column)
       return text
+    } else {
+      return ""
     }
   }
 

--- a/test/patch.test.js
+++ b/test/patch.test.js
@@ -5,6 +5,21 @@ import TestDocument from './helpers/test-document'
 import './helpers/add-to-html-methods'
 
 describe('Patch', function () {
+  describe('.prototype.getChangesInReverse()', function () {
+    it('returns changes that can be spliced into a patch in reverse', function () {
+      let patch = new Patch()
+      patch.splice({row: 0, column: 3}, {row: 0, column: 2}, {row: 3, column: 4})
+      patch.splice({row: 5, column: 10}, {row: 0, column: 0}, {row: 1, column: 1})
+      patch.splice({row: 8, column: 20}, {row: 0, column: 0}, {row: 0, column: 3})
+      patch.splice({row: 8, column: 28}, {row: 0, column: 0}, {row: 0, column: 1})
+
+      let reversePatch = new Patch()
+      patch.getChangesInReverse().reverse().forEach(change => reversePatch.splice(change.start, change.oldExtent, change.newExtent))
+
+      assert.deepEqual(patch.getChanges(), reversePatch.getChanges())
+    })
+  })
+
   it('correctly records basic non-overlapping splices', function () {
     let patch = new Patch()
     patch.spliceWithText({row: 0, column: 3}, {row: 0, column: 4}, 'hello')

--- a/test/patch.test.js
+++ b/test/patch.test.js
@@ -5,30 +5,13 @@ import TestDocument from './helpers/test-document'
 import './helpers/add-to-html-methods'
 
 describe('Patch', function () {
-  describe('.prototype.getInputChanges()', function () {
-    it('returns changes that can be spliced into a patch in reverse', function () {
-      let patch = new Patch()
-      patch.splice({row: 0, column: 1}, {row: 0, column: 3}, {row: 0, column: 0})
-      patch.splice({row: 0, column: 3}, {row: 0, column: 2}, {row: 3, column: 4})
-      patch.splice({row: 5, column: 4}, {row: 0, column: 3}, {row: 0, column: 4})
-      patch.splice({row: 5, column: 10}, {row: 0, column: 0}, {row: 1, column: 1})
-      patch.splice({row: 8, column: 20}, {row: 0, column: 0}, {row: 0, column: 3})
-      patch.splice({row: 8, column: 28}, {row: 0, column: 0}, {row: 0, column: 1})
-
-      let reversePatch = new Patch()
-      patch.getInputChanges().forEach(change => reversePatch.splice(change.start, change.oldExtent, change.newExtent))
-
-      assert.deepEqual(patch.getChanges(), reversePatch.getChanges())
-    })
-  })
-
   it('correctly records basic non-overlapping splices', function () {
     let patch = new Patch()
     patch.spliceWithText({row: 0, column: 3}, {row: 0, column: 4}, 'hello')
     patch.spliceWithText({row: 0, column: 10}, {row: 0, column: 5}, 'world')
     assert.deepEqual(patch.getChanges(), [
-      {start: {row: 0, column: 3}, oldExtent: {row: 0, column: 4}, newExtent: {row: 0, column: 5}, newText: 'hello'},
-      {start: {row: 0, column: 10}, oldExtent: {row: 0, column: 5}, newExtent: {row: 0, column: 5}, newText: 'world'}
+      {inputStart: {row: 0, column: 3}, outputStart: {row: 0, column: 3}, oldExtent: {row: 0, column: 4}, newExtent: {row: 0, column: 5}, newText: 'hello'},
+      {inputStart: {row: 0, column: 9}, outputStart: {row: 0, column: 10}, oldExtent: {row: 0, column: 5}, newExtent: {row: 0, column: 5}, newText: 'world'}
     ])
   })
 
@@ -37,7 +20,7 @@ describe('Patch', function () {
     patch.spliceWithText({row: 0, column: 3}, {row: 0, column: 4}, 'hello world')
     patch.spliceWithText({row: 0, column: 9}, {row: 0, column: 7}, 'sun')
     assert.deepEqual(patch.getChanges(), [
-      {start: {row: 0, column: 3}, oldExtent: {row: 0, column: 6}, newExtent: {row: 0, column: 9}, newText: 'hello sun'},
+      {inputStart: {row: 0, column: 3}, outputStart: {row: 0, column: 3}, oldExtent: {row: 0, column: 6}, newExtent: {row: 0, column: 9}, newText: 'hello sun'},
     ])
   })
 
@@ -82,8 +65,8 @@ describe('Patch', function () {
       assert.equal(synthesizedOutput, output.getText(), seedMessage)
 
       input = input.clone()
-      for (let {start, oldExtent, newText} of patch.getChanges()) {
-        input.splice(start, oldExtent, newText)
+      for (let {outputStart, oldExtent, newText} of patch.getChanges()) {
+        input.splice(outputStart, oldExtent, newText)
       }
       assert.equal(input.getText(), output.getText(), seedMessage)
     }
@@ -103,8 +86,8 @@ describe('Patch', function () {
       assert.equal(synthesizedOutput, output.getText(), seedMessage)
 
       input = input.clone()
-      for (let {start, oldExtent, newText} of patch.getInputChanges()) {
-        input.splice(start, oldExtent, newText)
+      for (let {inputStart, oldExtent, newText} of patch.getChanges().reverse()) {
+        input.splice(inputStart, oldExtent, newText)
       }
       assert.equal(input.getText(), output.getText(), seedMessage)
     }

--- a/test/patch.test.js
+++ b/test/patch.test.js
@@ -8,7 +8,9 @@ describe('Patch', function () {
   describe('.prototype.getChangesInReverse()', function () {
     it('returns changes that can be spliced into a patch in reverse', function () {
       let patch = new Patch()
+      patch.splice({row: 0, column: 1}, {row: 0, column: 3}, {row: 0, column: 0})
       patch.splice({row: 0, column: 3}, {row: 0, column: 2}, {row: 3, column: 4})
+      patch.splice({row: 5, column: 4}, {row: 0, column: 3}, {row: 0, column: 4})
       patch.splice({row: 5, column: 10}, {row: 0, column: 0}, {row: 1, column: 1})
       patch.splice({row: 8, column: 20}, {row: 0, column: 0}, {row: 0, column: 3})
       patch.splice({row: 8, column: 28}, {row: 0, column: 0}, {row: 0, column: 1})

--- a/test/patch.test.js
+++ b/test/patch.test.js
@@ -5,7 +5,7 @@ import TestDocument from './helpers/test-document'
 import './helpers/add-to-html-methods'
 
 describe('Patch', function () {
-  describe('.prototype.getChangesInReverse()', function () {
+  describe('.prototype.getInputChanges()', function () {
     it('returns changes that can be spliced into a patch in reverse', function () {
       let patch = new Patch()
       patch.splice({row: 0, column: 1}, {row: 0, column: 3}, {row: 0, column: 0})
@@ -16,7 +16,7 @@ describe('Patch', function () {
       patch.splice({row: 8, column: 28}, {row: 0, column: 0}, {row: 0, column: 1})
 
       let reversePatch = new Patch()
-      patch.getChangesInReverse().forEach(change => reversePatch.splice(change.start, change.oldExtent, change.newExtent))
+      patch.getInputChanges().forEach(change => reversePatch.splice(change.start, change.oldExtent, change.newExtent))
 
       assert.deepEqual(patch.getChanges(), reversePatch.getChanges())
     })
@@ -68,7 +68,7 @@ describe('Patch', function () {
 
     function verifySynthesizedOutput (patch, input, output, seedMessage) {
       let synthesizedOutput = ''
-      patch.iterator.rewind()
+      patch.iterator.moveToBeginning()
       do {
         if (patch.iterator.inChange()) {
           assert(!(isZeroPoint(patch.iterator.getInputExtent()) && isZeroPoint(patch.iterator.getOutputExtent())), "Empty region found. " + seedMessage);

--- a/test/patch.test.js
+++ b/test/patch.test.js
@@ -14,7 +14,7 @@ describe('Patch', function () {
       patch.splice({row: 8, column: 28}, {row: 0, column: 0}, {row: 0, column: 1})
 
       let reversePatch = new Patch()
-      patch.getChangesInReverse().reverse().forEach(change => reversePatch.splice(change.start, change.oldExtent, change.newExtent))
+      patch.getChangesInReverse().forEach(change => reversePatch.splice(change.start, change.oldExtent, change.newExtent))
 
       assert.deepEqual(patch.getChanges(), reversePatch.getChanges())
     })

--- a/test/patch.test.js
+++ b/test/patch.test.js
@@ -5,6 +5,22 @@ import TestDocument from './helpers/test-document'
 import './helpers/add-to-html-methods'
 
 describe('Patch', function () {
+  it('correctly composes changes from multiple patches', function () {
+    let patches = [new Patch(), new Patch(), new Patch()]
+    patches[0].spliceWithText({row: 0, column: 3}, {row: 0, column: 4}, 'hello')
+    patches[0].spliceWithText({row: 1, column: 1}, {row: 0, column: 0}, 'hey')
+    patches[1].splice({row: 0, column: 15}, {row: 0, column: 10}, {row: 0, column: 0})
+    patches[1].splice({row: 0, column: 0}, {row: 0, column: 0}, {row: 3, column: 0})
+    patches[2].spliceWithText({row: 4, column: 2}, {row: 0, column: 2}, 'ho')
+
+    assert.deepEqual(Patch.composeChanges(patches.map(p => p.getChanges())), [
+      {oldStart: {row: 0, column: 0}, newStart: {row: 0, column: 0}, oldExtent: {row: 0, column: 0}, newExtent: {row: 3, column: 0}},
+      {oldStart: {row: 0, column: 3}, newStart: {row: 3, column: 3}, oldExtent: {row: 0, column: 4}, newExtent: {row: 0, column: 5}, newText: 'hello'},
+      {oldStart: {row: 0, column: 14}, newStart: {row: 3, column: 15}, oldExtent: {row: 0, column: 10}, newExtent: {row: 0, column: 0}},
+      {oldStart: {row: 1, column: 1}, newStart: {row: 4, column: 1}, oldExtent: {row: 0, column: 0}, newExtent: {row: 0, column: 3}, newText: 'hho'}
+    ])
+  })
+
   it('correctly records basic non-overlapping splices', function () {
     let patch = new Patch()
     patch.spliceWithText({row: 0, column: 3}, {row: 0, column: 4}, 'hello')

--- a/test/patch.test.js
+++ b/test/patch.test.js
@@ -13,7 +13,7 @@ describe('Patch', function () {
     patches[1].splice({row: 0, column: 0}, {row: 0, column: 0}, {row: 3, column: 0})
     patches[2].spliceWithText({row: 4, column: 2}, {row: 0, column: 2}, 'ho')
 
-    assert.deepEqual(Patch.composeChanges(patches.map(p => p.getChanges())), [
+    assert.deepEqual(Patch.compose(patches), [
       {oldStart: {row: 0, column: 0}, newStart: {row: 0, column: 0}, oldExtent: {row: 0, column: 0}, newExtent: {row: 3, column: 0}},
       {oldStart: {row: 0, column: 3}, newStart: {row: 3, column: 3}, oldExtent: {row: 0, column: 4}, newExtent: {row: 0, column: 5}, newText: 'hello'},
       {oldStart: {row: 0, column: 14}, newStart: {row: 3, column: 15}, oldExtent: {row: 0, column: 10}, newExtent: {row: 0, column: 0}},
@@ -102,7 +102,7 @@ describe('Patch', function () {
       assert.equal(synthesizedOutput, output.getText(), seedMessage)
 
       input = input.clone()
-      for (let {oldStart, oldExtent, newText} of patch.getChanges().reverse()) {
+      for (let {oldStart, oldExtent, newText} of patch.getChanges().slice().reverse()) {
         input.splice(oldStart, oldExtent, newText)
       }
       assert.equal(input.getText(), output.getText(), seedMessage)

--- a/test/patch.test.js
+++ b/test/patch.test.js
@@ -10,8 +10,8 @@ describe('Patch', function () {
     patch.spliceWithText({row: 0, column: 3}, {row: 0, column: 4}, 'hello')
     patch.spliceWithText({row: 0, column: 10}, {row: 0, column: 5}, 'world')
     assert.deepEqual(patch.getChanges(), [
-      {inputStart: {row: 0, column: 3}, outputStart: {row: 0, column: 3}, oldExtent: {row: 0, column: 4}, newExtent: {row: 0, column: 5}, newText: 'hello'},
-      {inputStart: {row: 0, column: 9}, outputStart: {row: 0, column: 10}, oldExtent: {row: 0, column: 5}, newExtent: {row: 0, column: 5}, newText: 'world'}
+      {oldStart: {row: 0, column: 3}, newStart: {row: 0, column: 3}, oldExtent: {row: 0, column: 4}, newExtent: {row: 0, column: 5}, newText: 'hello'},
+      {oldStart: {row: 0, column: 9}, newStart: {row: 0, column: 10}, oldExtent: {row: 0, column: 5}, newExtent: {row: 0, column: 5}, newText: 'world'}
     ])
   })
 
@@ -20,7 +20,7 @@ describe('Patch', function () {
     patch.spliceWithText({row: 0, column: 3}, {row: 0, column: 4}, 'hello world')
     patch.spliceWithText({row: 0, column: 9}, {row: 0, column: 7}, 'sun')
     assert.deepEqual(patch.getChanges(), [
-      {inputStart: {row: 0, column: 3}, outputStart: {row: 0, column: 3}, oldExtent: {row: 0, column: 6}, newExtent: {row: 0, column: 9}, newText: 'hello sun'},
+      {oldStart: {row: 0, column: 3}, newStart: {row: 0, column: 3}, oldExtent: {row: 0, column: 6}, newExtent: {row: 0, column: 9}, newText: 'hello sun'},
     ])
   })
 
@@ -65,8 +65,8 @@ describe('Patch', function () {
       assert.equal(synthesizedOutput, output.getText(), seedMessage)
 
       input = input.clone()
-      for (let {outputStart, oldExtent, newText} of patch.getChanges()) {
-        input.splice(outputStart, oldExtent, newText)
+      for (let {newStart, oldExtent, newText} of patch.getChanges()) {
+        input.splice(newStart, oldExtent, newText)
       }
       assert.equal(input.getText(), output.getText(), seedMessage)
     }
@@ -86,8 +86,8 @@ describe('Patch', function () {
       assert.equal(synthesizedOutput, output.getText(), seedMessage)
 
       input = input.clone()
-      for (let {inputStart, oldExtent, newText} of patch.getChanges().reverse()) {
-        input.splice(inputStart, oldExtent, newText)
+      for (let {oldStart, oldExtent, newText} of patch.getChanges().reverse()) {
+        input.splice(oldStart, oldExtent, newText)
       }
       assert.equal(input.getText(), output.getText(), seedMessage)
     }


### PR DESCRIPTION
Over the weekend I have worked on a change that allows to splice in flip-flop into a `Patch` in order to aggregate changes from previous patches (e.g. we may use this in `TextBuffer`). It does so by modifying the existing `getChanges` interface and providing both an `inputStart` and an `outputStart`, so that we can write:

``` coffee
# flip
aggregatePatch = new Patch
for change in changes1
  aggregatePatch.splice(change.outputStart, change.oldExtent, change.newExtent, {text: change.newText})

# flop
for change in changes2 by -1
  aggregatePatch.splice(change.inputStart, change.oldExtent, change.newExtent, {text: change.newText})
```

The underlying reason why this should perform faster is that splay trees are well suited for locality, so splicing into a `Patch` from first to last and then from last to first should allow us to drop the factor of rotating and traversing the tree, as the nodes that were accessed last in the previous splice will be accessed first in the next splice.
## Patch Benchmarks

Benchmarks performed via the following snippet:

``` js
  describe('benchmarks', function () {
    it('normal', function () {
      let patch = new Patch()
      for (var i = 0; i < 20000; i++) { patch.spliceWithText({row: i, column: 0}, {row: 0, column: 0}, 'h') }
      patch.rebalance()
      for (var i = 0; i < 20000; i++) { patch.spliceWithText({row: i, column: 1}, {row: 0, column: 0}, 'e') }
      patch.rebalance()
      for (var i = 0; i < 20000; i++) { patch.spliceWithText({row: i, column: 2}, {row: 0, column: 0}, 'l') }
      patch.rebalance()
      for (var i = 0; i < 20000; i++) { patch.spliceWithText({row: i, column: 3}, {row: 0, column: 0}, 'l') }
      patch.rebalance()
      for (var i = 0; i < 20000; i++) { patch.spliceWithText({row: i, column: 4}, {row: 0, column: 0}, 'o') }
      patch.rebalance()
    })

    it('flip-flop', function () {
      let patch = new Patch()
      for (var i = 0; i < 20000; i++) { patch.spliceWithText({row: i, column: 0}, {row: 0, column: 0}, 'o') }
      for (var i = 20000; i >= 0; i--) { patch.spliceWithText({row: i, column: 1}, {row: 0, column: 0}, 'l') }
      for (var i = 0; i < 20000; i++) { patch.spliceWithText({row: i, column: 2}, {row: 0, column: 0}, 'l') }
      for (var i = 20000; i >= 0; i--) { patch.spliceWithText({row: i, column: 3}, {row: 0, column: 0}, 'e') }
      for (var i = 0; i < 20000; i++) { patch.spliceWithText({row: i, column: 4}, {row: 0, column: 0}, 'h') }
    })
  })
```

Results are quite promising:

![screen shot 2016-02-22 at 10 27 53](https://cloud.githubusercontent.com/assets/482957/13214296/12720dfe-d94f-11e5-95c2-1ba99068c164.png)
## TextBuffer Benchmarks

Benchmarks performed by writing 5 letters on 5000 cursors.
### Before

![screen shot 2016-02-22 at 10 47 41](https://cloud.githubusercontent.com/assets/482957/13214815/049162e0-d952-11e5-9acd-cd14dbe06f5e.png)

**Total:** `~ 700ms`.
### After

![screen shot 2016-02-22 at 10 48 08](https://cloud.githubusercontent.com/assets/482957/13214833/1dfff7c8-d952-11e5-97fc-ac9e7a9bdc07.png)

**Total:** `~ 400ms`, almost a 2x improvement. :racehorse: 
### Conclusions

I still believe that dropping this library to C++ would have lots of advantages and could make this code at least twice as fast. Given that is much less interactive than `MarkerIndex` we wouldn't even incur in the cost of serializing objects back and forth from native code. :horse_racing: 

/cc: @nathansobo @maxbrunsfeld @kuychaco 
