### PR TITLE
Introduce `oldText` in Patch.prototype.splice()

### DIFF
--- a/src/iterator.js
+++ b/src/iterator.js
@@ -110,7 +110,7 @@ export default class Iterator {
     if (!this.currentNode) {
       this.patch.root = new Node(null, boundaryOutputPosition, boundaryOutputPosition)
       this.patch.nodesCount++
-      return {node: this.patch.root}
+      return {node: this.patch.root, intersectsOldText: false}
     }
 
     while (true) {
@@ -131,7 +131,7 @@ export default class Iterator {
           break
         }
       } else if (comparison === 0 && this.currentNode !== spliceStartNode) {
-        return {node: this.currentNode}
+        return {node: this.currentNode, intersectsOldText: false}
       } else { // comparison > 0
         if (this.currentNode.right) {
           this.descendRight()
@@ -147,7 +147,7 @@ export default class Iterator {
       }
     }
 
-    let intersectsChange = false
+    let intersectsOldText = false
     if (this.rightAncestor && this.rightAncestor.isChangeEnd) {
       this.currentNode.isChangeStart = true
       this.currentNode.isChangeEnd = true
@@ -163,11 +163,11 @@ export default class Iterator {
           this.currentNode.oldText = oldText.substring(0, boundaryIndex)
           this.rightAncestor.oldText = oldText.substring(boundaryIndex)
         }
-        intersectsChange = true
+        intersectsOldText = true
       }
     }
 
-    return {node: this.currentNode, intersectsChange}
+    return {node: this.currentNode, intersectsOldText}
   }
 
   setCurrentNode (node) {

--- a/src/iterator.js
+++ b/src/iterator.js
@@ -147,7 +147,7 @@ export default class Iterator {
       }
     }
 
-    let oldTextSplitPositionStart, oldTextSplitPositionEnd
+    let intersectsChange = false
     if (this.rightAncestor && this.rightAncestor.isChangeEnd) {
       this.currentNode.isChangeStart = true
       this.currentNode.isChangeEnd = true
@@ -162,14 +162,12 @@ export default class Iterator {
         if (insertingStart) {
           this.currentNode.oldText = oldText.substring(0, boundaryIndex)
           this.rightAncestor.oldText = oldText.substring(boundaryIndex)
-          oldTextSplitPositionStart = boundaryIndex
-        } else {
-          oldTextSplitPositionEnd = boundaryIndex
         }
+        intersectsChange = true
       }
     }
 
-    return {node: this.currentNode, oldTextSplitPositionStart, oldTextSplitPositionEnd}
+    return {node: this.currentNode, intersectsChange}
   }
 
   setCurrentNode (node) {

--- a/src/iterator.js
+++ b/src/iterator.js
@@ -110,7 +110,7 @@ export default class Iterator {
     if (!this.currentNode) {
       this.patch.root = new Node(null, boundaryOutputPosition, boundaryOutputPosition)
       this.patch.nodesCount++
-      return {node: this.patch.root, intersectsOldText: false}
+      return this.patch.root
     }
 
     while (true) {
@@ -131,7 +131,7 @@ export default class Iterator {
           break
         }
       } else if (comparison === 0 && this.currentNode !== spliceStartNode) {
-        return {node: this.currentNode, intersectsOldText: false}
+        return this.currentNode
       } else { // comparison > 0
         if (this.currentNode.right) {
           this.descendRight()
@@ -147,7 +147,6 @@ export default class Iterator {
       }
     }
 
-    let intersectsOldText = false
     if (this.rightAncestor && this.rightAncestor.isChangeEnd) {
       this.currentNode.isChangeStart = true
       this.currentNode.isChangeEnd = true
@@ -159,15 +158,12 @@ export default class Iterator {
       }
       if (oldText != null) {
         let boundaryIndex = characterIndexForPoint(oldText, traversalDistance(boundaryOutputPosition, this.leftAncestorOutputPosition))
-        if (insertingStart) {
-          this.currentNode.oldText = oldText.substring(0, boundaryIndex)
-          this.rightAncestor.oldText = oldText.substring(boundaryIndex)
-        }
-        intersectsOldText = true
+        this.currentNode.oldText = oldText.substring(0, boundaryIndex)
+        this.rightAncestor.oldText = oldText.substring(boundaryIndex)
       }
     }
 
-    return {node: this.currentNode, intersectsOldText}
+    return this.currentNode
   }
 
   setCurrentNode (node) {

--- a/src/node.js
+++ b/src/node.js
@@ -14,5 +14,6 @@ export default class Node {
     this.isChangeStart = false
     this.isChangeEnd = false
     this.newText = null
+    this.oldText = null
   }
 }

--- a/src/patch.js
+++ b/src/patch.js
@@ -78,7 +78,7 @@ export default class Patch {
     this.splice(newStart, getExtent(oldText), getExtent(newText), {oldText, newText})
   }
 
-  splice (newStart, oldExtent, newExtent, options) {
+  splice (newStart, oldExtent, newExtent, options = {}) {
     if (isZeroPoint(oldExtent) && isZeroPoint(newExtent)) return
 
     let oldEnd = traverse(newStart, oldExtent)
@@ -95,10 +95,8 @@ export default class Patch {
 
     endNode.outputExtent = traverse(newEnd, traversalDistance(endNode.outputExtent, endNode.outputLeftExtent))
     endNode.outputLeftExtent = newEnd
-    endNode.newText = options && options.newText
-    if (options && options.oldText != null) {
-      endNode.oldText = this.replaceChangedText(options.oldText, startNode, endNode)
-    }
+    if (options.newText != null) endNode.newText = options.newText
+    if (options.oldText != null) endNode.oldText = this.replaceChangedText(options.oldText, startNode, endNode)
 
     startNode.right = null
     startNode.inputExtent = startNode.inputLeftExtent

--- a/src/patch.js
+++ b/src/patch.js
@@ -84,11 +84,13 @@ export default class Patch {
     let oldEnd = traverse(newStart, oldExtent)
     let newEnd = traverse(newStart, newExtent)
 
-    let {node: startNode, intersectsChange: startNodeIntersectsChange} = this.iterator.insertSpliceBoundary(newStart)
+    let {node: startNode, intersectsOldText: startNodeIntersectsOldText} =
+      this.iterator.insertSpliceBoundary(newStart)
     startNode.isChangeStart = true
     this.splayNode(startNode)
 
-    let {node: endNode, intersectsChange: endNodeIntersectsChange} = this.iterator.insertSpliceBoundary(oldEnd, startNode)
+    let {node: endNode, intersectsOldText: endNodeIntersectsOldText} =
+      this.iterator.insertSpliceBoundary(oldEnd, startNode)
     endNode.isChangeEnd = true
     this.splayNode(endNode)
     if (endNode.left !== startNode) this.rotateNodeRight(startNode)
@@ -101,9 +103,9 @@ export default class Patch {
     endNode.outputExtent = traverse(newEnd, traversalDistance(endNode.outputExtent, endNode.outputLeftExtent))
     endNode.outputLeftExtent = newEnd
     endNode.newText = options && options.newText
-    endNode.oldText = this.trimOldText(
-      options && options.oldText, endNode.oldText,
-      intersectingChanges, startNodeIntersectsChange, endNodeIntersectsChange
+    endNode.oldText = options && options.oldText && this.trimOldText(
+      options.oldText, endNode.oldText,
+      intersectingChanges, startNodeIntersectsOldText, endNodeIntersectsOldText
     )
 
     if (endNode.isChangeStart) {
@@ -144,7 +146,7 @@ export default class Patch {
     return changes
   }
 
-  trimOldText (newOldText, previousOldText, intersectingChanges, startNodeIntersectsChange, endNodeIntersectsChange) {
+  trimOldText (newOldText, previousOldText, intersectingChanges, startNodeIntersectsOldText, endNodeIntersectsOldText) {
     if (intersectingChanges.length > 0) {
       let text = ""
       let previousChangeEnd = ZERO_POINT
@@ -165,7 +167,7 @@ export default class Patch {
       if (previousChangeEnd) text += newOldText.substring(characterIndexForPoint(newOldText, previousChangeEnd))
       if (previousOldText) text += previousOldText
       return text
-    } else if (previousOldText == null && !startNodeIntersectsChange && !endNodeIntersectsChange) {
+    } else if (previousOldText == null && !startNodeIntersectsOldText && !endNodeIntersectsOldText) {
       return newOldText
     } else {
       return previousOldText

--- a/src/patch.js
+++ b/src/patch.js
@@ -101,7 +101,7 @@ export default class Patch {
     endNode.outputExtent = traverse(newEnd, traversalDistance(endNode.outputExtent, endNode.outputLeftExtent))
     endNode.outputLeftExtent = newEnd
     endNode.newText = options && options.newText
-    endNode.oldText = this.computeOldText(
+    endNode.oldText = this.trimOldText(
       options.oldText, endNode.oldText,
       changes, startNodeIntersectsChange, endNodeIntersectsChange
     )
@@ -144,7 +144,7 @@ export default class Patch {
     return changes
   }
 
-  computeOldText (newOldText, previousOldText, intersectingChanges, startNodeIntersectsChange, endNodeIntersectsChange) {
+  trimOldText (newOldText, previousOldText, intersectingChanges, startNodeIntersectsChange, endNodeIntersectsChange) {
     if (intersectingChanges.length > 0) {
       let text = ""
       let previousChangeEnd = null
@@ -161,9 +161,9 @@ export default class Patch {
           previousChangeEnd = change.end
         }
       }
+
       if (previousChangeEnd) text += newOldText.substring(characterIndexForPoint(newOldText, previousChangeEnd))
       if (previousOldText) text += previousOldText
-
       return text
     } else if (previousOldText == null && !startNodeIntersectsChange && !endNodeIntersectsChange) {
       return newOldText

--- a/src/patch.js
+++ b/src/patch.js
@@ -10,12 +10,12 @@ export default class Patch {
       if ((index & 1) === 0) { // flip
         for (let i = 0; i < changes.length; i++) {
           let {newStart, oldExtent, newExtent, newText} = changes[i]
-          composedPatch.splice(newStart, oldExtent, newExtent, {text: newText})
+          composedPatch.splice(newStart, oldExtent, newExtent, {newText})
         }
       } else { // flop
         for (let i = changes.length - 1; i >= 0; i--) {
           let {oldStart, oldExtent, newExtent, newText} = changes[i]
-          composedPatch.splice(oldStart, oldExtent, newExtent, {text: newText})
+          composedPatch.splice(oldStart, oldExtent, newExtent, {newText})
         }
       }
     }
@@ -74,8 +74,8 @@ export default class Patch {
     }
   }
 
-  spliceWithText (newStart, oldExtent, newText, options) {
-    this.splice(newStart, oldExtent, getExtent(newText), {text: newText})
+  spliceWithText (newStart, oldExtent, newText) {
+    this.splice(newStart, oldExtent, getExtent(newText), {newText})
   }
 
   splice (newStart, oldExtent, newExtent, options) {
@@ -99,7 +99,7 @@ export default class Patch {
 
     endNode.outputExtent = traverse(newEnd, traversalDistance(endNode.outputExtent, endNode.outputLeftExtent))
     endNode.outputLeftExtent = newEnd
-    endNode.newText = options && options.text
+    endNode.newText = options && options.newText
 
     if (endNode.isChangeStart) {
       let rightAncestor = this.bubbleNodeDown(endNode)

--- a/src/text-helpers.js
+++ b/src/text-helpers.js
@@ -1,5 +1,3 @@
-import {isInfinity as isInfinityPoint} from './point-helpers'
-
 const NEWLINE_REG_EXP = /\n/g
 
 export function getExtent (text) {
@@ -23,8 +21,6 @@ export function getSuffix (text, prefixExtent) {
 }
 
 export function characterIndexForPoint(text, point) {
-  if (isInfinityPoint(point)) return text.length
-
   let {row, column} = point
   NEWLINE_REG_EXP.lastIndex = 0
   while (row-- > 0) NEWLINE_REG_EXP.exec(text)

--- a/src/text-helpers.js
+++ b/src/text-helpers.js
@@ -1,3 +1,5 @@
+import {isInfinity as isInfinityPoint} from './point-helpers'
+
 const NEWLINE_REG_EXP = /\n/g
 
 export function getExtent (text) {
@@ -21,6 +23,8 @@ export function getSuffix (text, prefixExtent) {
 }
 
 export function characterIndexForPoint(text, point) {
+  if (isInfinityPoint(point)) return text.length
+
   let {row, column} = point
   NEWLINE_REG_EXP.lastIndex = 0
   while (row-- > 0) NEWLINE_REG_EXP.exec(text)

--- a/test/helpers/add-to-html-methods.js
+++ b/test/helpers/add-to-html-methods.js
@@ -23,7 +23,7 @@ Node.prototype.toHTML = function (leftAncestorInputPosition = ZERO_POINT, leftAn
   let changeEnd = this.isChangeEnd ? ' &lt;&lt;' : ''
   let inputPosition = traverse(leftAncestorInputPosition, this.inputLeftExtent)
   let outputPosition = traverse(leftAncestorOutputPosition, this.outputLeftExtent)
-  s += '<td colspan="2">' + `[${this.id}]` + ' {' + JSON.stringify(this.newText)  + '} ' + changeEnd + formatPoint(inputPosition) + ' / ' + formatPoint(outputPosition) + changeStart + '</td>'
+  s += '<td colspan="2">' + `[${this.id}]` + ' {' + JSON.stringify(this.newText)  + '} ' + ` { ${JSON.stringify(this.oldText)} }` + changeEnd + formatPoint(inputPosition) + ' / ' + formatPoint(outputPosition) + changeStart + '</td>'
   s += '</tr>'
 
   if (this.left || this.right) {

--- a/test/helpers/test-document.js
+++ b/test/helpers/test-document.js
@@ -43,11 +43,12 @@ export default class TestDocument {
   performRandomSplice () {
     let range = this.buildRandomRange()
     let start = range.start
+    let oldText = this.getTextInRange(range.start, range.end)
     let oldExtent = pointHelpers.traversalDistance(range.end, range.start)
     let newText = this.buildRandomLines(2, true).join('\n')
     let newExtent = textHelpers.getExtent(newText)
     this.splice(start, oldExtent, newText)
-    return {start, oldExtent, newExtent, newText}
+    return {start, oldExtent, newExtent, newText, oldText}
   }
 
   splice (start, oldExtent, newText) {

--- a/test/patch.test.js
+++ b/test/patch.test.js
@@ -7,43 +7,43 @@ import './helpers/add-to-html-methods'
 describe('Patch', function () {
   it('correctly composes changes from multiple patches', function () {
     let patches = [new Patch(), new Patch(), new Patch()]
-    patches[0].spliceWithText({row: 0, column: 3}, {row: 0, column: 4}, 'hello')
-    patches[0].spliceWithText({row: 1, column: 1}, {row: 0, column: 0}, 'hey')
+    patches[0].spliceWithText({row: 0, column: 3}, 'ciao', 'hello')
+    patches[0].spliceWithText({row: 1, column: 1}, '', 'hey')
     patches[1].splice({row: 0, column: 15}, {row: 0, column: 10}, {row: 0, column: 0})
     patches[1].splice({row: 0, column: 0}, {row: 0, column: 0}, {row: 3, column: 0})
-    patches[2].spliceWithText({row: 4, column: 2}, {row: 0, column: 2}, 'ho')
+    patches[2].spliceWithText({row: 4, column: 2}, 'so', 'ho')
 
     assert.deepEqual(Patch.compose(patches), [
       {oldStart: {row: 0, column: 0}, newStart: {row: 0, column: 0}, oldExtent: {row: 0, column: 0}, newExtent: {row: 3, column: 0}},
-      {oldStart: {row: 0, column: 3}, newStart: {row: 3, column: 3}, oldExtent: {row: 0, column: 4}, newExtent: {row: 0, column: 5}, newText: 'hello'},
+      {oldStart: {row: 0, column: 3}, newStart: {row: 3, column: 3}, oldExtent: {row: 0, column: 4}, newExtent: {row: 0, column: 5}, newText: 'hello', oldText: 'ciao'},
       {oldStart: {row: 0, column: 14}, newStart: {row: 3, column: 15}, oldExtent: {row: 0, column: 10}, newExtent: {row: 0, column: 0}},
-      {oldStart: {row: 1, column: 1}, newStart: {row: 4, column: 1}, oldExtent: {row: 0, column: 0}, newExtent: {row: 0, column: 3}, newText: 'hho'}
+      {oldStart: {row: 1, column: 1}, newStart: {row: 4, column: 1}, oldExtent: {row: 0, column: 0}, newExtent: {row: 0, column: 3}, newText: 'hho', oldText: ''}
     ])
   })
 
   it('correctly records basic non-overlapping splices', function () {
     let patch = new Patch()
-    patch.spliceWithText({row: 0, column: 3}, {row: 0, column: 4}, 'hello')
-    patch.spliceWithText({row: 0, column: 10}, {row: 0, column: 5}, 'world')
+    patch.spliceWithText({row: 0, column: 3}, 'ciao', 'hello')
+    patch.spliceWithText({row: 0, column: 10}, 'quick', 'world')
     assert.deepEqual(patch.getChanges(), [
-      {oldStart: {row: 0, column: 3}, newStart: {row: 0, column: 3}, oldExtent: {row: 0, column: 4}, newExtent: {row: 0, column: 5}, newText: 'hello'},
-      {oldStart: {row: 0, column: 9}, newStart: {row: 0, column: 10}, oldExtent: {row: 0, column: 5}, newExtent: {row: 0, column: 5}, newText: 'world'}
+      {oldStart: {row: 0, column: 3}, newStart: {row: 0, column: 3}, oldExtent: {row: 0, column: 4}, newExtent: {row: 0, column: 5}, newText: 'hello', oldText: 'ciao'},
+      {oldStart: {row: 0, column: 9}, newStart: {row: 0, column: 10}, oldExtent: {row: 0, column: 5}, newExtent: {row: 0, column: 5}, newText: 'world', oldText: 'quick'}
     ])
   })
 
   it('correctly records basic overlapping splices', function () {
     let patch = new Patch()
-    patch.spliceWithText({row: 0, column: 3}, {row: 0, column: 4}, 'hello world')
-    patch.spliceWithText({row: 0, column: 9}, {row: 0, column: 7}, 'sun')
+    patch.spliceWithText({row: 0, column: 3}, 'hola', 'hello world')
+    patch.spliceWithText({row: 0, column: 9}, 'zapping', 'sun')
     assert.deepEqual(patch.getChanges(), [
-      {oldStart: {row: 0, column: 3}, newStart: {row: 0, column: 3}, oldExtent: {row: 0, column: 6}, newExtent: {row: 0, column: 9}, newText: 'hello sun'},
+      {oldStart: {row: 0, column: 3}, newStart: {row: 0, column: 3}, oldExtent: {row: 0, column: 6}, newExtent: {row: 0, column: 9}, newText: 'hello sun', oldText: 'holang'}
     ])
   })
 
   it('correctly records random splices', function () {
     this.timeout(Infinity)
 
-    for (let i = 0; i < 1000; i++) {
+    for (let i = 0; i < 100; i++) {
       let seed = Date.now()
       let seedMessage = `Random seed: ${seed}`
       let random = new Random(seed)
@@ -52,9 +52,9 @@ describe('Patch', function () {
       let patch = new Patch()
 
       for (let j = 0; j < 10; j++) {
-        let {start, oldExtent, newExtent, newText} = output.performRandomSplice()
-        patch.spliceWithText(start, oldExtent, newText)
-        // document.write(`<div>after splice(${formatPoint(start)}, ${formatPoint(oldExtent)}, ${formatPoint(newExtent)}, ${newText})</div>`)
+        let {start, oldText, oldExtent, newExtent, newText} = output.performRandomSplice()
+        patch.spliceWithText(start, oldText, newText)
+        // document.write(`<div>after splice(${formatPoint(start)}, ${formatPoint(oldExtent)}, ${formatPoint(newExtent)}, ${JSON.stringify(newText)}, ${JSON.stringify(oldText)})</div>`)
         // document.write(patch.toHTML())
         // document.write('<hr>')
 

--- a/test/patch.test.js
+++ b/test/patch.test.js
@@ -84,32 +84,44 @@ describe('Patch', function () {
       assert.equal(synthesizedInput, input.getText(), seedMessage)
       assert.equal(synthesizedOutput, output.getText(), seedMessage)
 
-      input = input.clone()
-      for (let {newStart, oldExtent, newText} of patch.getChanges()) {
-        input.splice(newStart, oldExtent, newText)
+      synthesizedInput = output.clone()
+      synthesizedOutput = input.clone()
+      for (let {oldStart, newStart, oldExtent, newExtent, oldText, newText} of patch.getChanges()) {
+        synthesizedInput.splice(oldStart, newExtent, oldText)
+        synthesizedOutput.splice(newStart, oldExtent, newText)
       }
-      assert.equal(input.getText(), output.getText(), seedMessage)
+
+      assert.equal(synthesizedInput.getText(), input.getText(), seedMessage)
+      assert.equal(synthesizedOutput.getText(), output.getText(), seedMessage)
     }
 
     function verifyInputChanges (patch, input, output, seedMessage) {
       patch.iterator.moveToEnd()
+      let synthesizedInput = input.getTextInRange(patch.iterator.getInputEnd(), INFINITY_POINT)
       let synthesizedOutput = input.getTextInRange(patch.iterator.getInputEnd(), INFINITY_POINT)
       do {
         if (patch.iterator.inChange()) {
           assert(!(isZeroPoint(patch.iterator.getInputExtent()) && isZeroPoint(patch.iterator.getOutputExtent())), "Empty region found. " + seedMessage);
           synthesizedOutput = patch.iterator.getNewText() + synthesizedOutput
+          synthesizedInput = patch.iterator.getOldText() + synthesizedInput
         } else {
           synthesizedOutput = input.getTextInRange(patch.iterator.getInputStart(), patch.iterator.getInputEnd()) + synthesizedOutput
+          synthesizedInput = input.getTextInRange(patch.iterator.getInputStart(), patch.iterator.getInputEnd()) + synthesizedInput
         }
       } while (patch.iterator.moveToPredecessor())
 
+      assert.equal(synthesizedInput, input.getText(), seedMessage)
       assert.equal(synthesizedOutput, output.getText(), seedMessage)
 
-      input = input.clone()
-      for (let {oldStart, oldExtent, newText} of patch.getChanges().slice().reverse()) {
-        input.splice(oldStart, oldExtent, newText)
+      synthesizedOutput = input.clone()
+      synthesizedInput = output.clone()
+      for (let {oldStart, newStart, oldExtent, newExtent, oldText, newText} of patch.getChanges().slice().reverse()) {
+        synthesizedOutput.splice(oldStart, oldExtent, newText)
+        synthesizedInput.splice(newStart, newExtent, oldText)
       }
-      assert.equal(input.getText(), output.getText(), seedMessage)
+
+      assert.equal(synthesizedOutput.getText(), output.getText(), seedMessage)
+      assert.equal(synthesizedInput.getText(), input.getText(), seedMessage)
     }
   })
 })

--- a/test/patch.test.js
+++ b/test/patch.test.js
@@ -68,16 +68,20 @@ describe('Patch', function () {
 
     function verifyOutputChanges (patch, input, output, seedMessage) {
       let synthesizedOutput = ''
+      let synthesizedInput = ''
       patch.iterator.moveToBeginning()
       do {
         if (patch.iterator.inChange()) {
           assert(!(isZeroPoint(patch.iterator.getInputExtent()) && isZeroPoint(patch.iterator.getOutputExtent())), "Empty region found. " + seedMessage);
           synthesizedOutput += patch.iterator.getNewText()
+          synthesizedInput += patch.iterator.getOldText()
         } else {
           synthesizedOutput += input.getTextInRange(patch.iterator.getInputStart(), patch.iterator.getInputEnd())
+          synthesizedInput += input.getTextInRange(patch.iterator.getInputStart(), patch.iterator.getInputEnd())
         }
       } while (patch.iterator.moveToSuccessor())
 
+      assert.equal(synthesizedInput, input.getText(), seedMessage)
       assert.equal(synthesizedOutput, output.getText(), seedMessage)
 
       input = input.clone()


### PR DESCRIPTION
This PR slightly changes the `splice` API to accommodate an `oldText` parameter which allows to combine and iterate the chunks of text that were deleted from the underlying buffer. The main purpose of these changes is to supplant text-buffer's `History` undo/redo stacks with a collection `Patch`es, as opposed to the current individual changes.

The main tricky problem was to replace the new text from the `oldText` string that users pass into `splice`: this is done by iterating over the changes in the `oldExtent` and gradually substituting those chunks that were not in the original text.

Feedback super welcome! :balloon: 

/cc: @nathansobo @maxbrunsfeld
