### PR TITLE
Reintroduce metadata splicing

### DIFF
--- a/src/iterator.js
+++ b/src/iterator.js
@@ -57,9 +57,8 @@ export default class Iterator {
         oldExtent: traversalDistance(this.inputEnd, this.inputStart),
         newExtent: traversalDistance(this.outputEnd, this.outputStart),
       }
-      if (this.currentNode.newText != null) {
-        change.newText = this.currentNode.newText
-      }
+      if (this.currentNode.newText != null) change.newText = this.currentNode.newText
+      if (this.currentNode.metadata != null) change.metadata = this.currentNode.metadata
 
       changes.push(change)
     }
@@ -97,6 +96,10 @@ export default class Iterator {
 
   getNewText () {
     return this.currentNode.newText
+  }
+
+  getMetadata () {
+    return this.currentNode.metadata
   }
 
   insertSpliceBoundary (boundaryOutputPosition, spliceStartNode) {

--- a/src/node.js
+++ b/src/node.js
@@ -14,5 +14,6 @@ export default class Node {
     this.isChangeStart = false
     this.isChangeEnd = false
     this.newText = null
+    this.metadata = null
   }
 }

--- a/src/patch.js
+++ b/src/patch.js
@@ -74,11 +74,11 @@ export default class Patch {
     }
   }
 
-  spliceWithText (newStart, oldExtent, newText, options) {
-    this.splice(newStart, oldExtent, getExtent(newText), {text: newText})
+  spliceWithText (newStart, oldExtent, newText, metadata) {
+    this.splice(newStart, oldExtent, getExtent(newText), {text: newText, metadata})
   }
 
-  splice (newStart, oldExtent, newExtent, options) {
+  splice (newStart, oldExtent, newExtent, options = {}) {
     if (isZeroPoint(oldExtent) && isZeroPoint(newExtent)) return
 
     let oldEnd = traverse(newStart, oldExtent)
@@ -99,7 +99,8 @@ export default class Patch {
 
     endNode.outputExtent = traverse(newEnd, traversalDistance(endNode.outputExtent, endNode.outputLeftExtent))
     endNode.outputLeftExtent = newEnd
-    endNode.newText = options && options.text
+    if (options.text != null) endNode.newText = options.text
+    if (options.metadata != null) endNode.metadata = options.metadata
 
     if (endNode.isChangeStart) {
       let rightAncestor = this.bubbleNodeDown(endNode)

--- a/test/patch.test.js
+++ b/test/patch.test.js
@@ -40,6 +40,32 @@ describe('Patch', function () {
     ])
   })
 
+  it('allows metadata to be associated with splices', () => {
+    let patch = new Patch()
+    patch.splice({row: 0, column: 3}, {row: 0, column: 4}, {row: 0, column: 5}, {metadata: {a: 1}})
+    patch.splice({row: 0, column: 10}, {row: 0, column: 5}, {row: 0, column: 5}, {metadata: {b: 2}})
+
+    let iterator = patch.buildIterator()
+    iterator.moveToBeginning()
+    assert(!iterator.inChange())
+
+    iterator.moveToSuccessor()
+    assert(iterator.inChange())
+    assert.deepEqual(iterator.getMetadata(), {a: 1})
+
+    iterator.moveToSuccessor()
+    assert(!iterator.inChange())
+
+    iterator.moveToSuccessor()
+    assert(iterator.inChange())
+    assert.deepEqual(iterator.getMetadata(), {b: 2})
+
+    assert.deepEqual(patch.getChanges(), [
+      {oldStart: {row: 0, column: 3}, newStart: {row: 0, column: 3}, oldExtent: {row: 0, column: 4}, newExtent: {row: 0, column: 5}, metadata: {a: 1}},
+      {oldStart: {row: 0, column: 9}, newStart: {row: 0, column: 10}, oldExtent: {row: 0, column: 5}, newExtent: {row: 0, column: 5}, metadata: {b: 2}}
+    ])
+  })
+
   it('correctly records random splices', function () {
     this.timeout(Infinity)
 


### PR DESCRIPTION
Refs: atom/text-buffer#135.

Putting the metadata back will allow us to store data such as `normalizeLineEndings` in TextBuffer's history, so that we can replay changes in the exact same way as they were originally performed.

/cc: @nathansobo 
