### PR TITLE
Add Patch.invert and Patch.hunk

### DIFF
--- a/src/patch.js
+++ b/src/patch.js
@@ -24,18 +24,13 @@ export default class Patch {
   }
 
   static invert (patch) {
-    let changes = patch.getChanges()
-    let invertedChanges = []
-    for (let change of changes) {
-      invertedChanges.push({
-        oldStart: change.newStart,
-        newStart: change.oldStart,
-        oldExtent: change.newExtent,
-        newExtent: change.oldExtent,
-        oldText: change.newText,
-        newText: change.oldText
-      })
-    }
+    let invertedChanges = patch.getChanges().map((change) => {
+      return {
+        oldStart: change.newStart, newStart: change.oldStart,
+        oldExtent: change.newExtent, newExtent: change.oldExtent,
+        oldText: change.newText, newText: change.oldText
+      }
+    })
 
     return new Patch({cachedChanges: invertedChanges})
   }

--- a/src/patch.js
+++ b/src/patch.js
@@ -35,7 +35,7 @@ export default class Patch {
     return new Patch({cachedChanges: invertedChanges})
   }
 
-  static withSingleChange (change) {
+  static hunk (change) {
     let changes = [{
       oldStart: change.newStart,
       newStart: change.newStart,

--- a/src/patch.js
+++ b/src/patch.js
@@ -20,7 +20,37 @@ export default class Patch {
       }
     }
 
-    return composedPatch.getChanges()
+    return new Patch({cachedChanges: composedPatch.getChanges()})
+  }
+
+  static invert (patch) {
+    let changes = patch.getChanges()
+    let invertedChanges = []
+    for (let change of changes) {
+      invertedChanges.push({
+        oldStart: change.newStart,
+        newStart: change.oldStart,
+        oldExtent: change.newExtent,
+        newExtent: change.oldExtent,
+        oldText: change.newText,
+        newText: change.oldText
+      })
+    }
+
+    return new Patch({cachedChanges: invertedChanges})
+  }
+
+  static withSingleChange (change) {
+    let changes = [{
+      oldStart: change.newStart,
+      newStart: change.newStart,
+      oldExtent: change.oldExtent,
+      newExtent: change.newExtent,
+      oldText: change.oldText,
+      newText: change.newText
+    }]
+
+    return new Patch({cachedChanges: changes})
   }
 
   constructor (params = {}) {
@@ -28,6 +58,10 @@ export default class Patch {
     this.nodesCount = 0
     this.iterator = this.buildIterator()
     this.cachedChanges = null
+    if (params.cachedChanges) {
+      this.cachedChanges = params.cachedChanges
+      this.splice = function () { throw new Error("Cannot splice into a read-only Patch!") }
+    }
   }
 
   buildIterator () {

--- a/test/patch.test.js
+++ b/test/patch.test.js
@@ -37,16 +37,16 @@ describe('Patch', function () {
     assert.throws(() => invertedPatch.splice({row: 0, column: 0}, {row: 1, column: 0}, {row: 2, column: 0}))
   })
 
-  it('provides a read-only view of a patch representing a single change', function () {
-    let singleChangePatch = Patch.withSingleChange({
+  it('provides a read-only view of a patch representing a single hunk', function () {
+    let hunk = Patch.hunk({
       newStart: {row: 0, column: 3},
       oldExtent: {row: 0, column: 5}, newExtent: {row: 0, column: 7},
       newText: 'ciao', oldText: 'hello'
     })
-    assert.deepEqual(singleChangePatch.getChanges(), [
+    assert.deepEqual(hunk.getChanges(), [
       {oldStart: {row: 0, column: 3}, newStart: {row: 0, column: 3}, oldExtent: {row: 0, column: 5}, newExtent: {row: 0, column: 7}, newText: 'ciao', oldText: 'hello'}
     ])
-    assert.throws(() => singleChangePatch.splice({row: 0, column: 0}, {row: 1, column: 0}, {row: 2, column: 0}))
+    assert.throws(() => hunk.splice({row: 0, column: 0}, {row: 1, column: 0}, {row: 2, column: 0}))
   })
 
   it('correctly records basic non-overlapping splices', function () {

--- a/test/patch.test.js
+++ b/test/patch.test.js
@@ -40,10 +40,8 @@ describe('Patch', function () {
   it('provides a read-only view of a patch representing a single change', function () {
     let singleChangePatch = Patch.withSingleChange({
       newStart: {row: 0, column: 3},
-      oldExtent: {row: 0, column: 5},
-      newExtent: {row: 0, column: 7},
-      newText: 'ciao',
-      oldText: 'hello'
+      oldExtent: {row: 0, column: 5}, newExtent: {row: 0, column: 7},
+      newText: 'ciao', oldText: 'hello'
     })
     assert.deepEqual(singleChangePatch.getChanges(), [
       {oldStart: {row: 0, column: 3}, newStart: {row: 0, column: 3}, oldExtent: {row: 0, column: 5}, newExtent: {row: 0, column: 7}, newText: 'ciao', oldText: 'hello'}

--- a/test/patch.test.js
+++ b/test/patch.test.js
@@ -5,7 +5,7 @@ import TestDocument from './helpers/test-document'
 import './helpers/add-to-html-methods'
 
 describe('Patch', function () {
-  it('correctly composes changes from multiple patches', function () {
+  it('provides a read-only view on the composition of multiple patches', function () {
     let patches = [new Patch(), new Patch(), new Patch()]
     patches[0].spliceWithText({row: 0, column: 3}, 'ciao', 'hello')
     patches[0].spliceWithText({row: 1, column: 1}, '', 'hey')
@@ -13,12 +13,42 @@ describe('Patch', function () {
     patches[1].splice({row: 0, column: 0}, {row: 0, column: 0}, {row: 3, column: 0})
     patches[2].spliceWithText({row: 4, column: 2}, 'so', 'ho')
 
-    assert.deepEqual(Patch.compose(patches), [
+    let composedPatch = Patch.compose(patches)
+    assert.deepEqual(composedPatch.getChanges(), [
       {oldStart: {row: 0, column: 0}, newStart: {row: 0, column: 0}, oldExtent: {row: 0, column: 0}, newExtent: {row: 3, column: 0}},
       {oldStart: {row: 0, column: 3}, newStart: {row: 3, column: 3}, oldExtent: {row: 0, column: 4}, newExtent: {row: 0, column: 5}, newText: 'hello', oldText: 'ciao'},
       {oldStart: {row: 0, column: 14}, newStart: {row: 3, column: 15}, oldExtent: {row: 0, column: 10}, newExtent: {row: 0, column: 0}},
       {oldStart: {row: 1, column: 1}, newStart: {row: 4, column: 1}, oldExtent: {row: 0, column: 0}, newExtent: {row: 0, column: 3}, newText: 'hho', oldText: ''}
     ])
+
+    assert.throws(() => composedPatch.splice({row: 0, column: 0}, {row: 1, column: 0}, {row: 2, column: 0}))
+  })
+
+  it('provides a read-only view on the inverse of a patch', function () {
+    let patch = new Patch()
+    patch.spliceWithText({row: 0, column: 3}, 'ciao', 'hello')
+    patch.spliceWithText({row: 0, column: 10}, 'quick', 'world')
+
+    let invertedPatch = Patch.invert(patch)
+    assert.deepEqual(invertedPatch.getChanges(), [
+      {oldStart: {row: 0, column: 3}, newStart: {row: 0, column: 3}, oldExtent: {row: 0, column: 5}, newExtent: {row: 0, column: 4}, newText: 'ciao', oldText: 'hello'},
+      {oldStart: {row: 0, column: 10}, newStart: {row: 0, column: 9}, oldExtent: {row: 0, column: 5}, newExtent: {row: 0, column: 5}, newText: 'quick', oldText: 'world'}
+    ])
+    assert.throws(() => invertedPatch.splice({row: 0, column: 0}, {row: 1, column: 0}, {row: 2, column: 0}))
+  })
+
+  it('provides a read-only view of a patch representing a single change', function () {
+    let singleChangePatch = Patch.withSingleChange({
+      newStart: {row: 0, column: 3},
+      oldExtent: {row: 0, column: 5},
+      newExtent: {row: 0, column: 7},
+      newText: 'ciao',
+      oldText: 'hello'
+    })
+    assert.deepEqual(singleChangePatch.getChanges(), [
+      {oldStart: {row: 0, column: 3}, newStart: {row: 0, column: 3}, oldExtent: {row: 0, column: 5}, newExtent: {row: 0, column: 7}, newText: 'ciao', oldText: 'hello'}
+    ])
+    assert.throws(() => singleChangePatch.splice({row: 0, column: 0}, {row: 1, column: 0}, {row: 2, column: 0}))
   })
 
   it('correctly records basic non-overlapping splices', function () {


### PR DESCRIPTION
These two methods return a `Patch` that's a read-only view respectively on another `Patch` and on an individual change (a hunk). This PR also changes `Patch.compose` to return a read-only `Patch` as opposed to a list of changes.
