### PR TITLE
Don't split oldText when intersecting an existing change

### DIFF
--- a/src/iterator.js
+++ b/src/iterator.js
@@ -157,7 +157,7 @@ export default class Iterator {
         this.rightAncestor.newText = newText.substring(boundaryIndex)
       }
       if (oldText != null) {
-        let boundaryIndex = characterIndexForPoint(oldText, traversalDistance(boundaryOutputPosition, this.leftAncestorOutputPosition))
+        let boundaryIndex = characterIndexForPoint(oldText, traverse(this.inputStart, traversalDistance(boundaryOutputPosition, this.leftAncestorOutputPosition)))
         this.currentNode.oldText = oldText.substring(0, boundaryIndex)
         this.rightAncestor.oldText = oldText.substring(boundaryIndex)
       }

--- a/src/iterator.js
+++ b/src/iterator.js
@@ -157,9 +157,8 @@ export default class Iterator {
         this.rightAncestor.newText = newText.substring(boundaryIndex)
       }
       if (oldText != null) {
-        let boundaryIndex = characterIndexForPoint(oldText, traverse(this.inputStart, traversalDistance(boundaryOutputPosition, this.leftAncestorOutputPosition)))
-        this.currentNode.oldText = oldText.substring(0, boundaryIndex)
-        this.rightAncestor.oldText = oldText.substring(boundaryIndex)
+        this.currentNode.oldText = oldText
+        this.rightAncestor.oldText = ""
       }
     }
 


### PR DESCRIPTION
When splicing a change that intersects some other change in the patch, we split the text between the nodes representing the changes, so that the newly inserted one represents the text spanning from the beginning of the previous change to the beginning of the new change, and its right ancestor contains the exceeding part. This technique allows to replace only the intersecting part of the two changes, and keep intact the the left and the right side of the intersection.

This, however, doesn't hold true for `oldText` because new changes that intersect a previous splice refer to a new coordinate space, which means we can just move the entire right ancestor's old text to the newly added node.

/cc: @nathansobo 
