### PR TITLE
Better intersecting changes text split

### DIFF
--- a/src/iterator.js
+++ b/src/iterator.js
@@ -152,12 +152,12 @@ export default class Iterator {
       this.currentNode.isChangeEnd = true
       let {newText, oldText} = this.rightAncestor
       if (newText != null) {
-        let boundaryIndex = characterIndexForPoint(newText, traversalDistance(boundaryOutputPosition, this.leftAncestorOutputPosition))
+        let boundaryIndex = characterIndexForPoint(newText, this.currentNode.outputLeftExtent)
         if (insertingStart) this.currentNode.newText = newText.substring(0, boundaryIndex)
         this.rightAncestor.newText = newText.substring(boundaryIndex)
       }
       if (oldText != null) {
-        let boundaryIndex = characterIndexForPoint(oldText, traversalDistance(boundaryOutputPosition, this.leftAncestorOutputPosition))
+        let boundaryIndex = characterIndexForPoint(oldText, this.currentNode.inputLeftExtent)
         this.currentNode.oldText = oldText.substring(0, boundaryIndex)
         this.rightAncestor.oldText = oldText.substring(boundaryIndex)
       }

--- a/src/text-helpers.js
+++ b/src/text-helpers.js
@@ -23,6 +23,11 @@ export function getSuffix (text, prefixExtent) {
 export function characterIndexForPoint(text, point) {
   let {row, column} = point
   NEWLINE_REG_EXP.lastIndex = 0
-  while (row-- > 0) NEWLINE_REG_EXP.exec(text)
+  while (row-- > 0) {
+    let matches = NEWLINE_REG_EXP.exec(text)
+    if (matches == null) {
+      return text.length
+    }
+  }
   return NEWLINE_REG_EXP.lastIndex + column
 }

--- a/test/helpers/test-document.js
+++ b/test/helpers/test-document.js
@@ -6,7 +6,7 @@ import * as textHelpers from '../../src/text-helpers'
 export default class TestDocument {
   constructor (randomSeed, text) {
     this.random = new Random(randomSeed)
-    this.lines = this.buildRandomLines(10)
+    this.lines = this.buildRandomLines(1, 50)
   }
 
   clone () {
@@ -45,7 +45,7 @@ export default class TestDocument {
     let start = range.start
     let oldText = this.getTextInRange(range.start, range.end)
     let oldExtent = pointHelpers.traversalDistance(range.end, range.start)
-    let newText = this.buildRandomLines(2, true).join('\n')
+    let newText = this.buildRandomLines(0, 10, true).join('\n')
     let newExtent = textHelpers.getExtent(newText)
     this.splice(start, oldExtent, newText)
     return {start, oldExtent, newExtent, newText, oldText}
@@ -67,8 +67,8 @@ export default class TestDocument {
     return this.lines[row][column]
   }
 
-  buildRandomLines (max, upperCase) {
-    let lineCount = this.random.intBetween(1, max - 1)
+  buildRandomLines (min, max, upperCase) {
+    let lineCount = this.random.intBetween(min, max - 1)
     let lines = []
     for (let i = 0; i < lineCount; i++) {
       lines.push(this.buildRandomLine(upperCase))
@@ -77,7 +77,7 @@ export default class TestDocument {
   }
 
   buildRandomLine (upperCase) {
-    let wordCount = this.random(5)
+    let wordCount = this.random(20)
     let words = []
     for (let i = 0; i < wordCount; i++) {
       words.push(this.buildRandomWord(upperCase))
@@ -93,15 +93,7 @@ export default class TestDocument {
 
   buildRandomRange () {
     let a = this.buildRandomPoint()
-    let b = a
-    while (this.random(10) < 5) {
-      b = this.clipPosition(
-        pointHelpers.traverse(b, {
-          row: this.random.intBetween(-10, 10),
-          column: this.random.intBetween(0, 10)
-        })
-      )
-    }
+    let b = this.buildRandomPoint()
 
     if (pointHelpers.compare(a, b) <= 0) {
       return {start: a, end: b}

--- a/test/patch.test.js
+++ b/test/patch.test.js
@@ -84,7 +84,7 @@ describe('Patch', function () {
   it('correctly records random splices', function () {
     this.timeout(Infinity)
 
-    for (let i = 0; i < 100; i++) {
+    for (let i = 0; i < 5000; i++) {
       let seed = Date.now()
       let seedMessage = `Random seed: ${seed}`
       let random = new Random(seed)
@@ -92,7 +92,7 @@ describe('Patch', function () {
       let output = input.clone()
       let patch = new Patch()
 
-      for (let j = 0; j < 10; j++) {
+      for (let j = 0; j < 25; j++) {
         let {start, oldText, oldExtent, newExtent, newText} = output.performRandomSplice()
         patch.spliceWithText(start, oldText, newText)
         // document.write(`<div>after splice(${formatPoint(start)}, ${formatPoint(oldExtent)}, ${formatPoint(newExtent)}, ${JSON.stringify(newText)}, ${JSON.stringify(oldText)})</div>`)


### PR DESCRIPTION
### The Problem

Back in #9 I was trying to address a problem caught in text-buffer. Namely, we were observing a weird behavior when the following splices occurred: 

``` js
"Splice 1": {row: 0, column: 4}, {row: 1, column: 22}, {row: 2, column: 12}, {oldText: "ttorsion\t\nlvaporific restful unf", newText: " exegete compound palaeontol\npropylene\nmonostrophe "}
"Splice 2": {row: 2, column: 8}, {row: 0, column: 4}, {row: 0, column: 0}, {oldText: "phe ", newText: ""}
```

The expected result would be a single change that looks like the following:

``` js
"Expected": {row: 0, column: 4}, {row: 1, column: 22}, {row: 2, column: 8}, {oldText: "ttorsion\t\nlvaporific restful unf", newText: " exegete compound palaeontol\npropylene\nmonostro"}
```

But the actual result we were getting was:

``` js
"Actual": {row: 0, column: 4}, {row: 1, column: 22}, {row: 2, column: 8}, {oldText: "ttorsion", newText: " exegete compound palaeontol\npropylene\nmonostro"}
```

One thing to notice here is that `Splice 2` starts **after** the previously deleted region in input coordinates but ends exactly at `Splice 1` end in output coordinates. In other words, this means that the user has deleted only text that belongs to the output space and, as such, shouldn't affect `oldText`. So, why did the previous implementation cut part of the old text?
### A solution

When splicing new nodes into the `Patch`, and their position is in the middle of a previous change, we treat that node as a change end, and move the prefix of the previous change's old text into this new node. When deciding which chunks of the text to cut, we apply the following reasoning:
1. If the new change's output end occurs before the corresponding input end of the previous change, we split the previously spliced `oldText` so that the new node contains from the start of such text up to the newly spliced output extent. Accordingly, we set the remaining part of the text to the node representing the previous change's end.
2. If the new change's output end occurs after the corresponding input end of the previous change, we split the previously spliced `oldText` so that the new node contains the whole text, and the node representing the previous change's end contains an empty string.

The previous code was failing to deal with the second case, because `textHelpers.characterIndexForPoint` was behaving weirdly when the supplied point was beyond the extent of the supplied text.

This PR fixes it by: 
1. Making `characterIndexForPoint` return the entire text's length whenever the point is out of bounds.
2. Using `this.currentNode.outputLeftExtent` and `this.currentNode.inputLeftExtent` as the boundary points where we should cut the text at, instead of recalculating the position ourselves (this works because those two extents already represent the exact extent that the node is occupying).
3. Making specs more exhaustive and thorough (e.g. splice lines that are more complex, splice with a `newExtent` of `(0, 0)`, add more iterations) 

@nathansobo: even if this is less performant than #9, I think it's better from a logical standpoint, because it tries to maintain the tree invariants when splicing the nodes, without having to wait for a successive repair step when deleting/bubbling nodes down.
