### PR TITLE
Fix misspelling of 'Xcode'

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ git clone https://github.com/google/flatbuffers
 git checkout 959866b
 
 # compile flatbuffers
-pushd flatbuffers/build/XCode/
+pushd flatbuffers/build/Xcode/
 xcodebuild
 popd
 ```


### PR DESCRIPTION
It's spelled correctly in the google repo now, see https://github.com/google/flatbuffers/blob/370e101a691b4aebad2aa75d5aa64b1dd058eb6b/.gitignore#L55-L56.
