### PR TITLE
Fix error when destroying a deserialized patch that has been splayed

### DIFF
--- a/src/patch.h
+++ b/src/patch.h
@@ -58,12 +58,13 @@ class Patch {
   void PerformRebalancingRotations(uint32_t);
   Node *BuildNode(Node *, Node *, Point, Point, Point, Point, std::unique_ptr<Text>, std::unique_ptr<Text>);
   void DeleteNode(Node **);
+  bool IsFrozen() const;
 
   struct PositionStackEntry;
   mutable std::vector<PositionStackEntry> left_ancestor_stack;
   mutable std::vector<Node *> node_stack;
   Node *root;
-  bool is_frozen;
+  Node *frozen_node_array;
   bool merges_adjacent_hunks;
   uint32_t hunk_count;
 };

--- a/test/patch.test.js
+++ b/test/patch.test.js
@@ -246,6 +246,8 @@ describe('Native Patch', function () {
         let blob = Buffer.from(patch.serialize().toString('base64'), 'base64')
         const patchCopy = Patch.deserialize(blob)
         assert.deepEqual(patchCopy.getHunks(), patch.getHunks())
+        let oldPoint = originalDocument.buildRandomPoint()
+        assert.deepEqual(patchCopy.hunkForOldPosition(oldPoint), patch.hunkForOldPosition(oldPoint))
       }
     }
   })


### PR DESCRIPTION
Deserializing a Patch is optimized by allocating all the nodes in a single contiguous array. Previously, we conflated the location of this array with the root of the tree, but these two locations can differ if the tree has been splayed. This fixes that problem by storing a separate pointer to the node array (null in the case of a non-frozen patch).

/cc @nathansobo