### PR TITLE
Add Patch.copy

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -208,6 +208,7 @@ public:
     const auto &prototype_template = constructor_template_local->PrototypeTemplate();
     prototype_template->Set(Nan::New("splice").ToLocalChecked(), Nan::New<FunctionTemplate>(Splice));
     prototype_template->Set(Nan::New("spliceOld").ToLocalChecked(), Nan::New<FunctionTemplate>(SpliceOld));
+    prototype_template->Set(Nan::New("copy").ToLocalChecked(), Nan::New<FunctionTemplate>(Copy));
     prototype_template->Set(Nan::New("invert").ToLocalChecked(), Nan::New<FunctionTemplate>(Invert));
     prototype_template->Set(Nan::New("getHunks").ToLocalChecked(), Nan::New<FunctionTemplate>(GetHunks));
     prototype_template->Set(Nan::New("getHunksInOldRange").ToLocalChecked(), Nan::New<FunctionTemplate>(GetHunksInOldRange));
@@ -278,6 +279,16 @@ private:
       if (!patch.SpliceOld(start.FromJust(), deletion_extent.FromJust(), insertion_extent.FromJust())) {
         Nan::ThrowError("Can't spliceOld into a frozen patch");
       }
+    }
+  }
+
+  static void Copy(const Nan::FunctionCallbackInfo<Value> &info) {
+    Local<Object> result;
+    if (Nan::NewInstance(Nan::New(constructor)).ToLocal(&result)) {
+      Patch &patch = Nan::ObjectWrap::Unwrap<PatchWrapper>(info.This())->patch;
+      auto wrapper = new PatchWrapper{patch.Copy()};
+      wrapper->Wrap(result);
+      info.GetReturnValue().Set(result);
     }
   }
 

--- a/src/patch.cc
+++ b/src/patch.cc
@@ -40,6 +40,18 @@ struct Node {
     }
   }
 
+  Node *Copy() {
+    return new Node{
+      left, right,
+      old_distance_from_left_ancestor,
+      new_distance_from_left_ancestor,
+      old_extent,
+      new_extent,
+      unique_ptr<Text>(new Text(*old_text)),
+      unique_ptr<Text>(new Text(*new_text)),
+    };
+  }
+
   Node *Invert() {
     return new Node {
       left, right,
@@ -769,6 +781,30 @@ bool Patch::SpliceOld(Point old_splice_start, Point old_deletion_extent, Point o
   }
 
   return true;
+}
+
+Patch Patch::Copy() {
+  Node *new_root = nullptr;
+  if (root) {
+    new_root = root->Copy();
+    node_stack.clear();
+    node_stack.push_back(new_root);
+
+    while (!node_stack.empty()) {
+      Node *node = node_stack.back();
+      node_stack.pop_back();
+      if (node->left) {
+        node->left = node->left->Copy();
+        node_stack.push_back(node->left);
+      }
+      if (node->right) {
+        node->right = node->right->Copy();
+        node_stack.push_back(node->right);
+      }
+    }
+  }
+
+  return Patch {new_root, hunk_count, merges_adjacent_hunks};
 }
 
 Patch Patch::Invert() {

--- a/src/patch.cc
+++ b/src/patch.cc
@@ -47,8 +47,8 @@ struct Node {
       new_distance_from_left_ancestor,
       old_extent,
       new_extent,
-      unique_ptr<Text>(new Text(*old_text)),
-      unique_ptr<Text>(new Text(*new_text)),
+      old_text ? old_text->Copy() : nullptr,
+      new_text ? new_text->Copy() : nullptr
     };
   }
 
@@ -59,8 +59,8 @@ struct Node {
       old_distance_from_left_ancestor,
       new_extent,
       old_extent,
-      unique_ptr<Text>(new Text(*new_text)),
-      unique_ptr<Text>(new Text(*old_text)),
+      new_text ? new_text->Copy() : nullptr,
+      old_text ? old_text->Copy() : nullptr
     };
   }
 };
@@ -113,8 +113,8 @@ Patch::Patch(const vector<const Patch *> &patches_to_compose) : Patch() {
           iter->new_start,
           iter->old_end.Traversal(iter->old_start),
           iter->new_end.Traversal(iter->new_start),
-          iter->old_text ? Text::Build(iter->old_text->content) : nullptr,
-          iter->new_text ? Text::Build(iter->new_text->content) : nullptr
+          iter->old_text ? iter->old_text->Copy() : nullptr,
+          iter->new_text ? iter->new_text->Copy() : nullptr
         );
       }
     } else {
@@ -123,8 +123,8 @@ Patch::Patch(const vector<const Patch *> &patches_to_compose) : Patch() {
           iter->old_start,
           iter->old_end.Traversal(iter->old_start),
           iter->new_end.Traversal(iter->new_start),
-          iter->old_text ? Text::Build(iter->old_text->content) : nullptr,
-          iter->new_text ? Text::Build(iter->new_text->content) : nullptr
+          iter->old_text ? iter->old_text->Copy() : nullptr,
+          iter->new_text ? iter->new_text->Copy() : nullptr
         );
       }
     }

--- a/src/patch.h
+++ b/src/patch.h
@@ -19,6 +19,7 @@ class Patch {
   bool Splice(Point start, Point deletion_extent, Point insertion_extent,
               std::unique_ptr<Text> old_text, std::unique_ptr<Text> new_text);
   bool SpliceOld(Point start, Point deletion_extent, Point insertion_extent);
+  Patch Copy();
   Patch Invert();
   std::vector<Hunk> GetHunks() const;
   std::vector<Hunk> GetHunksInNewRange(Point start, Point end, bool inclusive = false);

--- a/src/text.cc
+++ b/src/text.cc
@@ -43,7 +43,11 @@ Text::Text(TextSlice slice) : content{
   slice.text->content.begin() + slice.end_index
 } {}
 
-Text::Text(Text &other) : content{other.content} {}
+Text::Text(const Text &other) : content{other.content} {}
+
+unique_ptr<Text> Text::Copy() const {
+  return unique_ptr<Text>(new Text{*this});
+}
 
 std::pair<TextSlice, TextSlice> Text::Split(Point position) const {
   size_t index = CharacterIndexForPosition(position);

--- a/src/text.h
+++ b/src/text.h
@@ -27,8 +27,9 @@ struct Text {
 
   Text(std::vector<uint16_t> &&content);
   Text(TextSlice slice);
-  Text(Text&);
+  Text(const Text &other);
 
+  std::unique_ptr<Text> Copy() const;
   std::pair<TextSlice, TextSlice> Split(Point position) const;
   TextSlice Prefix(Point prefix_end) const;
   TextSlice Suffix(Point suffix_start) const;

--- a/test/patch.test.js
+++ b/test/patch.test.js
@@ -244,10 +244,15 @@ describe('Native Patch', function () {
         }
 
         let blob = Buffer.from(patch.serialize().toString('base64'), 'base64')
-        const patchCopy = Patch.deserialize(blob)
-        assert.deepEqual(patchCopy.getHunks(), patch.getHunks())
         let oldPoint = originalDocument.buildRandomPoint()
-        assert.deepEqual(patchCopy.hunkForOldPosition(oldPoint), patch.hunkForOldPosition(oldPoint))
+
+        const patchCopy1 = Patch.deserialize(blob)
+        assert.deepEqual(patchCopy1.getHunks(), patch.getHunks())
+        assert.deepEqual(patchCopy1.hunkForOldPosition(oldPoint), patch.hunkForOldPosition(oldPoint))
+
+        const patchCopy2 = patch.copy()
+        assert.deepEqual(patchCopy2.getHunks(), patch.getHunks())
+        assert.deepEqual(patchCopy2.hunkForOldPosition(oldPoint), patch.hunkForOldPosition(oldPoint))
       }
     }
   })

--- a/test/patch.test.js
+++ b/test/patch.test.js
@@ -100,9 +100,7 @@ describe('Native Patch', function () {
     const patch = new Patch()
     patch.splice({row: 0, column: 3}, {row: 0, column: 4}, {row: 0, column: 5}, 'ciao', 'hello')
     patch.splice({row: 0, column: 10}, {row: 0, column: 5}, {row: 0, column: 5}, 'quick', 'world')
-
-    const invertedPatch = patch.invert()
-    assert.deepEqual(JSON.parse(JSON.stringify(invertedPatch.getHunks())), [
+    assert.deepEqual(JSON.parse(JSON.stringify(patch.invert().getHunks())), [
       {
         oldStart: {row: 0, column: 3}, oldEnd: {row: 0, column: 8},
         newStart: {row: 0, column: 3}, newEnd: {row: 0, column: 7},
@@ -116,6 +114,32 @@ describe('Native Patch', function () {
         newText: 'quick'
       }
     ])
+
+    const patch2 = new Patch()
+    patch2.splice({row: 0, column: 3}, {row: 0, column: 4}, {row: 0, column: 5})
+    patch2.splice({row: 0, column: 10}, {row: 0, column: 5}, {row: 0, column: 5})
+    assert.deepEqual(JSON.parse(JSON.stringify(patch2.invert().getHunks())), [
+      {
+        oldStart: {row: 0, column: 3}, oldEnd: {row: 0, column: 8},
+        newStart: {row: 0, column: 3}, newEnd: {row: 0, column: 7}
+      },
+      {
+        oldStart: {row: 0, column: 10}, oldEnd: {row: 0, column: 15},
+        newStart: {row: 0, column: 9}, newEnd: {row: 0, column: 14}
+      }
+    ])
+  })
+
+  it('can copy patches', function () {
+    const patch = new Patch()
+    patch.splice({row: 0, column: 3}, {row: 0, column: 4}, {row: 0, column: 5}, 'ciao', 'hello')
+    patch.splice({row: 0, column: 10}, {row: 0, column: 5}, {row: 0, column: 5}, 'quick', 'world')
+    assert.deepEqual(patch.copy().getHunks(), patch.getHunks())
+
+    const patch2 = new Patch()
+    patch2.splice({row: 0, column: 3}, {row: 0, column: 4}, {row: 0, column: 5})
+    patch2.splice({row: 0, column: 10}, {row: 0, column: 5}, {row: 0, column: 5})
+    assert.deepEqual(patch2.copy().getHunks(), patch2.getHunks())
   })
 
   it('can serialize/deserialize patches', () => {


### PR DESCRIPTION
This will allow us to implement `DisplayLayer.copy` more efficiently in `text-buffer`, so that we can avoid redundant work when splitting a pane containing a large file in Atom.